### PR TITLE
Transitions-driven cluster lock/unlock example

### DIFF
--- a/astacus/coordinator/api.py
+++ b/astacus/coordinator/api.py
@@ -1,0 +1,91 @@
+"""
+Copyright (c) 2020 Aiven Ltd
+See LICENSE for details
+"""
+
+from .config import coordinator_config, CoordinatorConfig
+from .locker import LockerContext, LockerFSM
+from .state import coordinator_state, CoordinatorState
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from urllib.parse import urljoin
+
+FSM_APP_KEY = "coordinator_fsm"
+
+router = APIRouter()
+
+
+class Coordinator:
+    """ Convenience dependency which contains sub-dependencies most API endpoints need """
+    def __init__(self,
+                 *,
+                 request: Request,
+                 background_tasks: BackgroundTasks,
+                 config: CoordinatorConfig = Depends(coordinator_config),
+                 state: CoordinatorState = Depends(coordinator_state)):
+        self.request = request
+        self.background_tasks = background_tasks
+        self.config = config
+        self.state = state
+
+
+def start_fsm(*, c: Coordinator, fsm_class, context, initial):
+    """
+    Start a FSM instance with given fsm_class and context,
+    starting at initial state.
+    """
+    fsm = fsm_class(context=context, initial=initial)
+    current_fsm = getattr(c.request.app.state, FSM_APP_KEY, None)
+    if current_fsm and current_fsm.is_running():
+        raise HTTPException(503, "An operation is already ongoing")
+    if current_fsm:
+        setattr(c.state.fsm, current_fsm.context_name, None)
+    setattr(c.request.app.state, FSM_APP_KEY, fsm)
+    c.state.fsm.fsm_class = "%s.%s" % (fsm.__class__.__module__,
+                                       fsm.__class__.__qualname__)
+    c.state.op += 1
+    setattr(c.state.fsm, fsm.context_name, context)
+    c.background_tasks.add_task(fsm.run)
+    status_url = urljoin(str(c.request.url), f"../status/{c.state.op}")
+    return {"status-url": status_url}
+
+
+@router.post("/lock")
+def lock(*, locker: str, ttl: int = 60, c: Coordinator = Depends()):
+    context = LockerContext(locker=locker,
+                            ttl=ttl,
+                            unlocked_nodes=c.config.nodes[:])
+    result = start_fsm(c=c,
+                       fsm_class=LockerFSM,
+                       context=context,
+                       initial="lock")
+    result["unlock-url"] = urljoin(str(c.request.url),
+                                   f"../unlock?locker={locker}")
+    return result
+
+
+@router.get("/unlock")
+def unlock(
+        *,
+        locker: str,
+        c: Coordinator = Depends(),
+):
+    context = LockerContext(locker=locker, locked_nodes=c.config.nodes[:])
+    result = start_fsm(c=c,
+                       fsm_class=LockerFSM,
+                       context=context,
+                       initial="unlock")
+    return result
+
+
+@router.get("/status/{op}")
+def status(
+        *,
+        op: int,
+        c: Coordinator = Depends(),
+):
+    if op != c.state.op:
+        raise HTTPException(404, "Unknown operation id")
+    fsm = getattr(c.request.app.state, FSM_APP_KEY, None)
+    if not fsm:
+        return {}
+    return {"state": fsm.state}

--- a/astacus/coordinator/config.py
+++ b/astacus/coordinator/config.py
@@ -1,0 +1,52 @@
+"""
+Copyright (c) 2020 Aiven Ltd
+See LICENSE for details
+"""
+
+from astacus.common import utils
+from fastapi import Depends, Request
+from pydantic import BaseModel  # pylint: disable=no-name-in-module # ( sometimes Cython -> pylint won't work )
+from threading import Lock
+from typing import List
+
+APP_KEY = "coordinator_config"
+APP_LOCK_KEY = "coordinator_config_lock"
+
+
+class Node(BaseModel):
+    url: str
+
+
+class CoordinatorConfig(BaseModel):
+    nodes: List[Node] = []
+
+
+def raw_coordinator_config(request: Request) -> CoordinatorConfig:
+    return utils.get_or_create_state(request=request,
+                                     key=APP_KEY,
+                                     factory=CoordinatorConfig)
+
+
+def coordinator_lock(request: Request) -> Lock:
+    """Acquire Lock to have access to CoordinatorConfig
+
+    It is intentionally not RLock, as depends are resolved in main
+    asyncio event loop thread, and due to that, every request could
+    acquire same RLock without issues. Plain old Lock works, but care
+    should be taken in not trying to lock multiple times as that will
+    deadlock.
+
+    For longer requests combination of raw_coordinator_config + coordinator_lock
+    + with (only in critical sections) in the different thread should
+    be used.
+    """
+    return utils.get_or_create_state(request=request,
+                                     key=APP_LOCK_KEY,
+                                     factory=Lock)
+
+
+def coordinator_config(
+        config: CoordinatorConfig = Depends(raw_coordinator_config),
+        lock: Lock = Depends(coordinator_lock)) -> CoordinatorConfig:
+    with lock:
+        yield config

--- a/astacus/coordinator/fsm.py
+++ b/astacus/coordinator/fsm.py
@@ -1,0 +1,39 @@
+"""Copyright (c) 2020 Aiven Ltd
+See LICENSE for details
+
+This is (persisted) FSM convenience class on top of
+transitions.LockedMachine.
+
+Neat things:
+
+- snapshots its own context regularly
+
+  - doesn't require locking (as long as it is just fired up in a
+    thread, and snapshot is accessed and reference kept from another)
+
+"""
+
+from transitions import Machine
+
+import copy
+
+
+class FSM(Machine):
+    def __init__(self, *, initial, states, terminal_states, context_name,
+                 context):
+        Machine.__init__(self,
+                         initial=initial,
+                         states=states,
+                         after_state_change="_snapshot_context")
+        self.terminal_states = terminal_states
+        self._context = context
+        self._snapshot_context()
+        self._running_states = set(states) - set(terminal_states)
+        self.add_transition("run", list(self._running_states), "=")
+        self.context_name = context_name
+
+    def _snapshot_context(self):
+        self.context_snapshot = copy.deepcopy(self._context)
+
+    def is_running(self):
+        return self.state not in self.terminal_states

--- a/astacus/coordinator/locker.py
+++ b/astacus/coordinator/locker.py
@@ -1,0 +1,76 @@
+"""
+
+Copyright (c) 2020 Aiven Ltd
+See LICENSE for details
+
+Bit of a hello-world example of what can be done with transitions.
+
+This could be equally well AsyncMachine, which would then run with
+proper aiohttp sub-calls.
+
+"""
+
+from .fsm import FSM
+from astacus.common import utils
+from pydantic import BaseModel  # pylint: disable=no-name-in-module # ( sometimes Cython -> pylint won't work )
+from typing import List
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class LockerContext(BaseModel):
+    locked_nodes: List = []
+    unlocked_nodes: List = []
+    locker: str = ''
+    ttl: int = 0
+    failing: bool = False
+
+
+class LockerFSM(FSM):
+    def __init__(self, *, context: LockerContext, initial=None):
+        FSM.__init__(self,
+                     terminal_states=["fail", "done"],
+                     states=["lock", "unlock", "fail", "done"],
+                     initial=initial,
+                     context=context,
+                     context_name="locker")
+        self.add_transition("fail", "lock", "unlock")
+        self.add_transition("fail", "unlock", "done")
+        self.add_transition("done", "lock", "done")
+        self.add_transition("done",
+                            "unlock",
+                            "fail",
+                            conditions=["is_failing"])
+        self.add_transition("done", "unlock", "done")
+
+    def on_enter_lock(self):
+        if not self._context.unlocked_nodes:
+            self.done()
+            return
+        node = self._context.unlocked_nodes.pop()
+        url = f"{node.url}/lock?locker={self._context.locker}&ttl={self._context.ttl}"
+        r = utils.http_request(url, caller="LockerFSM.lock")
+        if not r:
+            logger.warning("Cluster lock failed on node %r", node)
+            self._context.failing = True
+            self.fail()
+            return
+        self._context.locked_nodes.append(node)
+        self.run()
+
+    def on_enter_unlock(self):
+        if not self._context.locked_nodes:
+            self.done()
+            return
+        node = self._context.locked_nodes.pop()
+        url = f"{node.url}/unlock?locker={self._context.locker}"
+        r = utils.http_request(url, caller="LockerFSM.unlock")
+        if not r:
+            self.fail()
+            return
+        self.run()
+
+    def is_failing(self):
+        return self._context.failing

--- a/astacus/coordinator/state.py
+++ b/astacus/coordinator/state.py
@@ -1,0 +1,64 @@
+"""
+Copyright (c) 2020 Aiven Ltd
+See LICENSE for details
+
+This state represents the state of the coordinator.
+
+It is persisted to disk, and stored in the app.state.
+
+"""
+
+from .locker import LockerContext
+from astacus.common import utils
+from fastapi import Depends, Request
+from pydantic import BaseModel  # pylint: disable=no-name-in-module # ( sometimes Cython -> pylint won't work )
+from pydantic import Field
+from threading import Lock
+from typing import Optional
+
+APP_KEY = "coordinator_state"
+APP_LOCK_KEY = "coordinator_state_lock"
+
+
+class FSMState(BaseModel):
+    fsm_class: str = ''
+    fsm_state: str = ''  # which state is the FSM in
+
+    # astacus.coordinator.locker fsm context
+    locker: Optional[LockerContext] = None
+
+
+class CoordinatorState(BaseModel):
+    op: int = 0
+    fsm: FSMState = Field(default_factory=FSMState)
+
+
+def raw_coordinator_state(request: Request) -> CoordinatorState:
+    return utils.get_or_create_state(request=request,
+                                     key=APP_KEY,
+                                     factory=CoordinatorState)
+
+
+def coordinator_lock(request: Request) -> Lock:
+    """Acquire Lock to have access to CoordinatorState
+
+    It is intentionally not RLock, as depends are resolved in main
+    asyncio event loop thread, and due to that, every request could
+    acquire same RLock without issues. Plain old Lock works, but care
+    should be taken in not trying to lock multiple times as that will
+    deadlock.
+
+    For longer requests combination of unlocked_coordinator_state + coordinator_lock
+    + with (only in critical sections) in the different thread should
+    be used.
+    """
+    return utils.get_or_create_state(request=request,
+                                     key=APP_LOCK_KEY,
+                                     factory=Lock)
+
+
+def coordinator_state(state: CoordinatorState = Depends(raw_coordinator_state),
+                      lock: Lock = Depends(
+                          coordinator_lock)) -> CoordinatorState:
+    with lock:
+        yield state

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ def _run():
         packages=setuptools.find_packages(exclude=["test"]),
         install_requires=[
             "fastapi==0.54.1",
+            "transitions==0.8.1",
         ],
         extras_require={},
         dependency_links=[],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+"""
+Copyright (c) 2020 Aiven Ltd
+See LICENSE for details
+"""
+
+from astacus.common import utils
+
+import logging
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(name="utils_http_request_list")
+def fixture_utils_http_request_list(mocker):
+    result_list = []
+
+    def _http_request(*args, **kwargs):
+        logger.info("utils_http_request_list %r %r", args, kwargs)
+        assert result_list, f"Unable to serve request {args!r} {kwargs!r}"
+        r = result_list.pop(0)
+        if isinstance(r, dict):
+            if 'args' in r:
+                assert list(r["args"]) == list(args)
+            if 'kwargs' in r:
+                assert r["kwargs"] == kwargs
+            return r["result"]
+        if r is None:
+            return None
+        raise NotImplementedError(f"Unknown item in utils_request_list: {r!r}")
+
+    mocker.patch.object(utils, "http_request", new=_http_request)
+    yield result_list
+    assert not result_list, f"Unconsumed requests: {result_list!r}"

--- a/tests/coordinator/conftest.py
+++ b/tests/coordinator/conftest.py
@@ -1,0 +1,27 @@
+"""
+Copyright (c) 2020 Aiven Ltd
+See LICENSE for details
+"""
+from astacus.coordinator.api import router
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import pytest
+
+
+@pytest.fixture(name="app")
+def fixture_app():
+    app = FastAPI()
+    app.include_router(router, tags=["coordinator"])
+    yield app
+
+
+@pytest.fixture(name="client")
+def fixture_client(app):
+    client = TestClient(app)
+
+    # One ping at API to populate the fixtures (ugh)
+    response = client.post("/lock")
+    assert response.status_code == 422, response.json()
+
+    yield client

--- a/tests/coordinator/test_lock.py
+++ b/tests/coordinator/test_lock.py
@@ -1,0 +1,101 @@
+"""
+Copyright (c) 2020 Aiven Ltd
+See LICENSE for details
+
+Test that the coordinator lock endpoint works.
+
+"""
+
+from astacus.coordinator.config import Node
+
+
+def test_lock_no_nodes(client):
+    # Without nodes, normal lock calls should be about instant
+    response = client.post("/lock?locker=x")
+    assert response.status_code == 200, response.json()
+
+    response = client.post("/lock?locker=y")
+    assert response.status_code == 200, response.json()
+    response = client.get(response.json()["status-url"])
+    assert response.status_code == 200, response.json()
+    assert response.json() == {"state": "done"}
+
+
+def test_lock_fail(app, client, utils_http_request_list):
+    # Add fake node that won't respond to API -> state won't be done
+    app.state.coordinator_config.nodes = [
+        Node(url="http://localhost:12345/asdf")
+    ]
+    utils_http_request_list.append({
+        "args": ["http://localhost:12345/asdf/lock?locker=z&ttl=60"],
+        "kwargs": {
+            "caller": "LockerFSM.lock"
+        },
+        "result":
+        None
+    })
+    response = client.post("/lock?locker=z")
+    assert response.status_code == 200, response.json()
+    assert not utils_http_request_list
+
+    response = client.get(response.json()["status-url"])
+    assert response.status_code == 200, response.json()
+    assert response.json() == {"state": "fail"}
+
+
+def test_lock_ok(app, client, utils_http_request_list):
+    app.state.coordinator_config.nodes = [
+        Node(url="http://localhost:12346/asdf"),
+        Node(url="http://localhost:12345/asdf"),
+    ]
+    # locker handles locking from last to first
+    utils_http_request_list.extend([{
+        "args": ["http://localhost:12345/asdf/lock?locker=z&ttl=60"],
+        "result": {
+            "locked": True
+        }
+    }, {
+        "args": ["http://localhost:12346/asdf/lock?locker=z&ttl=60"],
+        "result": {
+            "locked": True
+        }
+    }])
+    response = client.post("/lock?locker=z")
+    assert response.status_code == 200, response.json()
+
+    response = client.get(response.json()["status-url"])
+    assert response.status_code == 200, response.json()
+    assert response.json() == {"state": "done"}
+
+    assert app.state.coordinator_state.op == 1
+    assert app.state.coordinator_state.fsm.fsm_class == "astacus.coordinator.locker.LockerFSM"
+
+
+def test_lock_onefail(app, client, utils_http_request_list):
+    app.state.coordinator_config.nodes = [
+        Node(url="http://localhost:12346/asdf"),
+        Node(url="http://localhost:12345/asdf"),
+    ]
+    # locker handles locking from last to first
+    utils_http_request_list.extend([{
+        "args": ["http://localhost:12345/asdf/lock?locker=z&ttl=60"],
+        "result": {
+            "locked": True
+        }
+    }, {
+        "args": ["http://localhost:12346/asdf/lock?locker=z&ttl=60"],
+        "result":
+        None
+    }, {
+        "args": ["http://localhost:12345/asdf/unlock?locker=z"],
+        "result": {
+            "locked": False
+        },
+    }])
+    response = client.post("/lock?locker=z")
+    assert response.status_code == 200, response.json()
+    assert not utils_http_request_list
+
+    response = client.get(response.json()["status-url"])
+    assert response.status_code == 200, response.json()
+    assert response.json() == {"state": "fail"}


### PR DESCRIPTION
This is mostly for review purposes. What do you guys think about some sort of design like this? I made it so that the state could be auto-persisted automatically, and the state itself is stored in typesafe fashion (only missing part is snapshot => coordinator state, and then coordinator state => disk parts and their reverse, but data is there).
