### PR TITLE
Add metrics

### DIFF
--- a/astacus/common/op.py
+++ b/astacus/common/op.py
@@ -62,6 +62,9 @@ class Op:
         return True
 
     def set_status_fail(self):
+        if self.stats is not None:
+            name = self.__class__.__name__
+            self.stats.increase("astacus_fail", {"op": name})
         self.set_status(self.Status.fail)
 
 

--- a/astacus/common/utils.py
+++ b/astacus/common/utils.py
@@ -232,3 +232,7 @@ def parallel_map_to(*, fun, iterable, result_callback, n=None) -> bool:
 
 def now():
     return datetime.datetime.now(datetime.timezone.utc)
+
+
+def monotonic_time():
+    return time.monotonic()

--- a/astacus/coordinator/coordinator.py
+++ b/astacus/coordinator/coordinator.py
@@ -147,11 +147,6 @@ class CoordinatorOp(op.Op):
             logger.info("%s - permanent failure: %r", name, ex)
         self.set_status_fail()
 
-    def set_status_fail(self):
-        super().set_status_fail()
-        name = self.__class__.__name__
-        self.stats.increase("astacus_fail", {"op": name})
-
     async def wait_successful_results(self, start_results, *, result_class, all_nodes=True):
         urls = []
         for i, result in enumerate(start_results, 1):

--- a/astacus/coordinator/coordinator.py
+++ b/astacus/coordinator/coordinator.py
@@ -112,6 +112,11 @@ class CoordinatorOp(op.Op):
                 if decoded_result != expected_result:
                     logger.info("%s of %s failed - unexpected result %r", call, node, decoded_result)
                     rv = LockResult.failure
+        if rv == LockResult.failure and self.stats is not None:
+            self.stats.increase("astacus_lock_call_failure", tags={
+                "call": call,
+                "locker": locker,
+            })
         return rv
 
     async def request_lock_from_nodes(self, *, locker: str, ttl: int) -> bool:

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -43,7 +43,7 @@ class OpBase(CoordinatorOpWithClusterLock):
             logger.debug("step %d/%d: %s", i, len(self.steps), step)
             step_name = f"step_{step}"
             step_callable = getattr(self, step_name)
-            assert step_callable, "Step method {step_name} not found in {self!r}"
+            assert step_callable, f"Step method {step_name} not found in {self!r}"
             if self.stats is not None:
                 name = self.__class__.__name__
                 async with self.stats.async_timing_manager("astacus_step_duration", {"op": name, "step": step_name}):

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -44,7 +44,12 @@ class OpBase(CoordinatorOpWithClusterLock):
             step_name = f"step_{step}"
             step_callable = getattr(self, step_name)
             assert step_callable, "Step method {step_name} not found in {self!r}"
-            r = await step_callable()
+            if self.stats is not None:
+                name = self.__class__.__name__
+                async with self.stats.async_timing_manager("astacus_step_duration", {"op": name, "step": step_name}):
+                    r = await step_callable()
+            else:
+                r = await step_callable()
             if not r:
                 logger.info("Step %s failed", step)
                 return False

--- a/tests/unit/common/test_op_stats.py
+++ b/tests/unit/common/test_op_stats.py
@@ -1,0 +1,37 @@
+"""
+
+Copyright (c) 2020 Aiven Ltd
+See LICENSE for details
+
+Test stats sending.
+
+"""
+from astacus.common.statsd import StatsClient
+from astacus.coordinator.plugins.base import OpBase
+from unittest.mock import patch
+
+import pytest
+
+
+class DummyOp(OpBase):
+    def __init__(self):
+        # pylint: disable=super-init-not-called
+        self.steps = ["one", "two", "three"]
+        self.stats = StatsClient(config=None)
+
+    async def step_one(self):
+        return True
+
+    async def step_two(self):
+        return True
+
+    async def step_three(self):
+        return True
+
+
+@pytest.mark.asyncio
+async def test_op_stats():
+    op = DummyOp()
+    with patch.object(StatsClient, "timing") as mock_stats_timing:
+        await op.try_run()
+    assert mock_stats_timing.call_count == 3


### PR DESCRIPTION
Collects the following metrics from running operations:

  * `astacus_fail`, a counter reporting all failed operations, tagged with the op type
  * `astacus_step_duration`, a timing stat for each step of an operation, tagged with op type and step name
  * `astacus_lock_call_failure`,  a counter reporting locking failures, tagged with call (lock/unlock) and locker
  * `astacus_op_running_for`, a gauge with seconds the op has run as value, tagged with op type and id