### PR TITLE
Partial restore support (+ fixes)

### DIFF
--- a/astacus/common/exceptions.py
+++ b/astacus/common/exceptions.py
@@ -36,6 +36,12 @@ class CompressionOrEncryptionRequired(PermanentException):
     pass
 
 
+# rohmu has given us 'some' exception we do not support; assume it is
+# permanent until proven otherwise
+class RohmuException(PermanentException):
+    pass
+
+
 class TransientException(AstacusException):
     pass
 

--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -130,11 +130,24 @@ class SnapshotResult(NodeResult):
 
 
 class SnapshotDownloadRequest(NodeRequest):
-    # state to be downloaded
-    state: SnapshotState
-
     # which (sub)object storage entry should be used
     storage: str
+
+    # which backup
+    backup_name: str
+
+    # which snapshot within the backup
+    snapshot_index: int
+
+    # this is used to configure snapshotter; it is needed in the main
+    # thread of node, so due to that, it is included here and not
+    # retrieved via backup manifest.
+    root_globs: List[str]
+
+
+class SnapshotClearRequest(NodeRequest):
+    # Files not matching this are not deleted
+    root_globs: List[str]
 
 
 # coordinator.api

--- a/astacus/common/op.py
+++ b/astacus/common/op.py
@@ -50,10 +50,13 @@ class Op:
     def __init__(self, *, info: Info):
         self.info = info
 
-    def set_status(self, status: Status, *, from_status: Optional[Status] = None) -> bool:
-        assert self.op_id, "start_op() should be called before set_status()"
+    def check_op_id(self):
         if self.info.op_id != self.op_id:
             raise ExpiredOperationException("operation id mismatch")
+
+    def set_status(self, status: Status, *, from_status: Optional[Status] = None) -> bool:
+        assert self.op_id, "start_op() should be called before set_status()"
+        self.check_op_id()
         if from_status and from_status != self.info.op_status:
             return False
         if self.info.op_status == status:

--- a/astacus/common/utils.py
+++ b/astacus/common/utils.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 
 import asyncio
 import datetime
+import httpcore
 import httpx
 import json as _json
 import logging
@@ -108,12 +109,14 @@ async def httpx_request(url, *, caller, method="get", timeout=10, json: bool = T
             if ignore_status_code:
                 return r.json() if json else r
             logger.warning("Unexpected response status code from %s to %s: %s %r", url, caller, r.status_code, r.text)
+        except httpcore.ConnectError:
+            # Unfortunately at least current httpx leaks this
+            # exception without wrapping it. Future versions may
+            # address this hopefully. I believe httpx.TransportError
+            # replaces it in future versions once we upgrade.
+            pass
         except httpx.HTTPError as ex:
             logger.warning("Unexpected response from %s to %s: %r", url, caller, ex)
-        except asyncio.CancelledError:
-            raise
-        except Exception as ex:  # pylint: disable=broad-except
-            logger.error("Unexpected exception from %s to %s: %r", url, caller, ex)
         return None
 
 

--- a/astacus/common/utils.py
+++ b/astacus/common/utils.py
@@ -9,9 +9,9 @@ Shared utilities (between coordinator and node)
 
 """
 
+from fastapi import FastAPI
 from multiprocessing.dummy import Pool  # fastapi + fork = bad idea
 from pydantic import BaseModel
-from starlette.requests import Request
 
 import asyncio
 import datetime
@@ -59,12 +59,12 @@ class AstacusModel(BaseModel):
         return _json.loads(self.json(**kw))
 
 
-def get_or_create_state(*, request: Request, key: str, factory):
+def get_or_create_state(*, app: FastAPI, key: str, factory):
     """ Get or create sub-state entry (using factory callback) """
-    value = getattr(request.app.state, key, None)
+    value = getattr(app.state, key, None)
     if value is None:
         value = factory()
-        setattr(request.app.state, key, value)
+        setattr(app.state, key, value)
     return value
 
 

--- a/astacus/coordinator/coordinator.py
+++ b/astacus/coordinator/coordinator.py
@@ -325,7 +325,7 @@ class Coordinator(op.OpMixin):
             file_mstorage = MultiFileStorage(self.config.object_storage_cache)
             json_mstorage = MultiCachingJsonStorage(backend_mstorage=mstorage, cache_mstorage=file_mstorage)
         self.json_mstorage = json_mstorage
-        self.sync_lock = utils.get_or_create_state(request=request, key="sync_lock", factory=threading.RLock)
+        self.sync_lock = utils.get_or_create_state(app=request.app, key="sync_lock", factory=threading.RLock)
 
     async def start_op_async(self, *, op, op_name, fun):  # pylint: disable=redefined-outer-name
         if isinstance(op, CoordinatorOpWithClusterLock):

--- a/astacus/coordinator/coordinator.py
+++ b/astacus/coordinator/coordinator.py
@@ -74,7 +74,7 @@ class CoordinatorOp(op.Op):
         urls = [f"{node.url}/{url}" for node in nodes]
         aws = [utils.httpx_request(url, caller=caller, **kw) for url in urls]
         results = await asyncio.gather(*aws, return_exceptions=True)
-        logger.debug("request_from_nodes %r => %r", nodes, results)
+        logger.info("request_from_nodes %r => %r", urls, results)
         return results
 
     async def request_lock_call_from_nodes(self, *, call: LockCall, locker: str, ttl: int = 0, nodes=None) -> LockResult:

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -40,6 +40,9 @@ class OpBase(CoordinatorOpWithClusterLock):
 
     async def try_run(self) -> bool:
         for i, step in enumerate(self.steps, 1):
+            if self.state.shutting_down:
+                logger.info("Step %s not even started due to shutdown", step)
+                return False
             logger.debug("step %d/%d: %s", i, len(self.steps), step)
             step_name = f"step_{step}"
             step_callable = getattr(self, step_name)

--- a/astacus/coordinator/plugins/m3db.py
+++ b/astacus/coordinator/plugins/m3db.py
@@ -181,6 +181,9 @@ class M3DRestoreOp(ETCDRestoreOpBase):
         key.set_value_bytes(placement.SerializeToString())
 
     async def step_rewrite_etcd(self):
+        if self.req.partial_restore_nodes:
+            logger.debug("Skipping etcd rewrite due to partial backup restoration")
+            return True
         etcd = self.plugin_manifest.etcd.copy(deep=True)
         for prefix in etcd.prefixes:
             for key in prefix.keys:
@@ -190,6 +193,9 @@ class M3DRestoreOp(ETCDRestoreOpBase):
         return etcd
 
     async def step_restore_etcd(self):
+        if self.req.partial_restore_nodes:
+            logger.debug("Skipping etcd restoration due to partial backup restoration")
+            return True
         return await self.restore_etcd_dump(self.result_rewrite_etcd)
 
 

--- a/astacus/coordinator/state.py
+++ b/astacus/coordinator/state.py
@@ -12,7 +12,7 @@ By design it cannot be persisted to disk, but e.g. op_info can be if necessary.
 from astacus.common import ipc, utils
 from astacus.common.op import OpState
 from dataclasses import dataclass
-from fastapi import Request
+from fastapi import FastAPI, Request
 from pydantic import Field
 from typing import Optional
 
@@ -38,7 +38,12 @@ class CoordinatorState(OpState):
     """
     cached_list_response: Optional[CachedListResponse] = None
     cached_list_running: bool = False
+    shutting_down: bool = False
+
+
+async def app_coordinator_state(app: FastAPI) -> CoordinatorState:
+    return utils.get_or_create_state(app=app, key=APP_KEY, factory=CoordinatorState)
 
 
 async def coordinator_state(request: Request) -> CoordinatorState:
-    return utils.get_or_create_state(request=request, key=APP_KEY, factory=CoordinatorState)
+    return await app_coordinator_state(app=request.app)

--- a/astacus/node/clear.py
+++ b/astacus/node/clear.py
@@ -1,0 +1,44 @@
+"""
+
+Copyright (c) 2020 Aiven Ltd
+See LICENSE for details
+
+Clearing of snapshot storage (separate from empty 'download' step for clarity)
+
+"""
+
+from .node import NodeOp
+from .snapshotter import Snapshotter
+from astacus.common import ipc
+from typing import Optional
+
+import contextlib
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ClearOp(NodeOp):
+    snapshotter: Optional[Snapshotter] = None
+
+    def start(self, *, req: ipc.SnapshotClearRequest):
+        self.req = req
+        self.snapshotter = self.get_or_create_snapshotter(req.root_globs)
+        logger.debug("start_clear %r", req)
+        return self.start_op(op_name="clear", op=self, fun=self.clear)
+
+    def clear(self):
+        assert self.snapshotter
+        # 'snapshotter' is global; ensure we have sole access to it
+        with self.snapshotter.lock:
+            self.check_op_id()
+            self.snapshotter.snapshot()
+            files = set(self.snapshotter.relative_path_to_snapshotfile.keys())
+            progress = self.result.progress
+            progress.start(len(files))
+            for relative_path in files:
+                absolute_path = self.config.root / relative_path
+                with contextlib.suppress(FileNotFoundError):
+                    absolute_path.unlink()
+                progress.add_success()
+            progress.done()

--- a/astacus/node/download.py
+++ b/astacus/node/download.py
@@ -124,12 +124,17 @@ class DownloadOp(NodeOp):
 
     def download(self):
         assert self.snapshotter
-        downloader = Downloader(
-            dst=self.config.root,
-            snapshotter=self.snapshotter,
-            storage=self.storage,
-            parallel=self.config.parallel.downloads
-        )
-        downloader.download_from_storage(
-            snapshotstate=self.req.state, progress=self.result.progress, still_running_callback=self.still_running_callback
-        )
+        # 'snapshotter' is global; ensure we have sole access to it
+        with self.snapshotter.lock:
+            self.check_op_id()
+            downloader = Downloader(
+                dst=self.config.root,
+                snapshotter=self.snapshotter,
+                storage=self.storage,
+                parallel=self.config.parallel.downloads
+            )
+            downloader.download_from_storage(
+                snapshotstate=self.req.state,
+                progress=self.result.progress,
+                still_running_callback=self.still_running_callback
+            )

--- a/astacus/node/node.py
+++ b/astacus/node/node.py
@@ -101,7 +101,7 @@ class Node(op.OpMixin):
         def _create_snapshotter():
             return Snapshotter(src=self.config.root, dst=root_link, globs=root_globs, parallel=self.config.parallel.hashes)
 
-        return utils.get_or_create_state(request=self.request, key=SNAPSHOTTER_KEY, factory=_create_snapshotter)
+        return utils.get_or_create_state(app=self.request.app, key=SNAPSHOTTER_KEY, factory=_create_snapshotter)
 
     def get_snapshotter(self):
         return getattr(self.request.app.state, SNAPSHOTTER_KEY)

--- a/astacus/node/state.py
+++ b/astacus/node/state.py
@@ -67,4 +67,4 @@ class NodeState(OpState):
 
 
 def node_state(request: Request) -> NodeState:
-    return utils.get_or_create_state(request=request, key=APP_KEY, factory=NodeState)
+    return utils.get_or_create_state(app=request.app, key=APP_KEY, factory=NodeState)

--- a/tests/unit/common/test_op_stats.py
+++ b/tests/unit/common/test_op_stats.py
@@ -9,6 +9,7 @@ Test stats sending.
 from astacus.common.op import Op
 from astacus.common.statsd import StatsClient
 from astacus.coordinator.plugins.base import OpBase
+from astacus.coordinator.state import CoordinatorState
 from unittest.mock import patch
 
 import pytest
@@ -21,6 +22,7 @@ class DummyOp(OpBase):
         self.steps = ["one", "two", "three"]
         self.stats = StatsClient(config=None)
         self.info = Op.Info(op_id=1)
+        self.state = CoordinatorState()
 
     async def step_one(self):
         return True

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -19,6 +19,13 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
+async def test_httpx_request_connect_failure():
+    # Known (most likely) unreachable local IP address
+    r = await utils.httpx_request("http://127.0.0.42:12345/foo", caller="test")
+    assert r is None
+
+
+@pytest.mark.asyncio
 async def test_exponential_backoff(mocker):
     _waits = []
     base = 42

--- a/tests/unit/coordinator/test_restore.py
+++ b/tests/unit/coordinator/test_restore.py
@@ -10,9 +10,12 @@ from astacus.common import exceptions, ipc, utils
 from astacus.coordinator.config import CoordinatorNode
 from astacus.coordinator.plugins import get_plugin_restore_class
 from contextlib import nullcontext as does_not_raise
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 import json
+import pydantic
 import pytest
 import respx
 
@@ -40,19 +43,29 @@ BACKUP_MANIFEST = ipc.BackupManifest(
 )
 
 
+@dataclass
+class RestoreTest:
+    fail_at: Optional[int] = None
+    partial: bool = False
+    storage_name: Optional[str] = None
+
+
 @pytest.mark.parametrize(
-    "storage_name,fail_at", [
-        (None, 1),
-        (None, 2),
-        (None, 3),
-        (None, None),
-        ("x", None),
-        ("y", None),
+    "rt",
+    [RestoreTest(fail_at=i) for i in range(1, 4)] + [
+        # success cases
+        RestoreTest(),  # default
+        # named storage
+        RestoreTest(storage_name="x"),
+        RestoreTest(storage_name="y"),
+        # partial
+        RestoreTest(partial=True)
     ]
 )
-def test_restore(storage_name, fail_at, app, client, mstorage):
+def test_restore(rt, app, client, mstorage):
+    fail_at = rt.fail_at
     # Create fake backup (not pretty but sufficient?)
-    storage = mstorage.get_storage(storage_name)
+    storage = mstorage.get_storage(rt.storage_name)
     storage.upload_json(BACKUP_NAME, BACKUP_MANIFEST)
     nodes = app.state.coordinator_config.nodes
     with respx.mock:
@@ -86,7 +99,12 @@ def test_restore(storage_name, fail_at, app, client, mstorage):
                 status_code=200 if fail_at != 3 else 500
             )
 
-        response = client.post("/restore", json={"storage": storage_name} if storage_name else None)
+        req = {}
+        if rt.storage_name:
+            req["storage"] = rt.storage_name
+        if rt.partial:
+            req["partial_restore_nodes"] = [{"node_index": 0, "backup_index": 0}]
+        response = client.post("/restore", json=req)
         if fail_at == 1:
             # Cluster lock failure is immediate
             assert response.status_code == 409, response.json()
@@ -100,7 +118,6 @@ def test_restore(storage_name, fail_at, app, client, mstorage):
             assert response.json() == {"state": "fail"}
         else:
             assert response.json() == {"state": "done"}
-
         assert app.state.coordinator_state.op_info.op_id == 1
 
 
@@ -113,6 +130,7 @@ class DummyRestoreOp(_RestoreOp):
         # NOP __init__, we mock whatever we care about
         self.nodes = nodes
         self.result_backup_manifest = manifest
+        self.req = ipc.RestoreRequest()
 
     def assert_node_to_backup_index_is(self, expected):
         assert self._get_node_to_backup_index() == expected
@@ -145,4 +163,82 @@ def test_node_to_backup_index(node_azlist, backup_azlist, expected_index, except
 
     op = DummyRestoreOp(nodes, manifest)
     with exception:
+        op.assert_node_to_backup_index_is(expected_index)
+
+
+@pytest.mark.parametrize(
+    "partial_node_spec,expected_index,exception",
+    [
+        # 4 (supported) ways of expressing same thing
+        ({
+            "backup_index": 1,
+            "node_index": 2
+        }, [None, None, 1], does_not_raise()),
+        ({
+            "backup_hostname": "host1",
+            "node_index": 2
+        }, [None, None, 1], does_not_raise()),
+        ({
+            "backup_index": 1,
+            "node_url": "url2"
+        }, [None, None, 1], does_not_raise()),
+        ({
+            "backup_hostname": "host1",
+            "node_url": "url2"
+        }, [None, None, 1], does_not_raise()),
+
+        # errors - invalid node spec
+        ({}, None, pytest.raises(pydantic.ValidationError)),
+        ({
+            "backup_index": 42,
+            "backup_hostname": "foo",
+            "node_index": 42
+        }, None, pytest.raises(pydantic.ValidationError)),
+        ({
+            "backup_index": 42,
+            "node_index": 42,
+            "node_url": "foo"
+        }, None, pytest.raises(pydantic.ValidationError)),
+
+        # out of range
+        ({
+            "backup_index": -1,
+            "node_index": 2
+        }, [None, None, 1], pytest.raises(exceptions.NotFoundException)),
+        ({
+            "backup_index": 1,
+            "node_index": -2
+        }, [None, None, 1], pytest.raises(exceptions.NotFoundException)),
+        ({
+            "backup_index": 123,
+            "node_index": 2
+        }, [None, None, 1], pytest.raises(exceptions.NotFoundException)),
+        ({
+            "backup_index": 1,
+            "node_index": 123
+        }, [None, None, 1], pytest.raises(exceptions.NotFoundException)),
+        # invalid url / hostname
+        ({
+            "backup_hostname": "host123",
+            "node_index": 2
+        }, [None, None, 1], pytest.raises(exceptions.NotFoundException)),
+        ({
+            "backup_index": 1,
+            "node_url": "url123"
+        }, [None, None, 1], pytest.raises(exceptions.NotFoundException)),
+    ]
+)
+def test_partial_node_to_backup_index(partial_node_spec, expected_index, exception):
+    num_nodes = 3
+    nodes = [CoordinatorNode(url=f"url{i}") for i in range(num_nodes)]
+    manifest = ipc.BackupManifest(
+        start=utils.now(),
+        attempt=1,
+        snapshot_results=[ipc.SnapshotResult(hostname=f"host{i}") for i in range(num_nodes)],
+        upload_results=[],
+        plugin="files"
+    )
+    op = DummyRestoreOp(nodes, manifest)
+    with exception:
+        op.req.partial_restore_nodes = [ipc.PartialRestoreRequestNode.parse_obj(partial_node_spec)]
         op.assert_node_to_backup_index_is(expected_index)

--- a/tests/unit/node/test_node_download.py
+++ b/tests/unit/node/test_node_download.py
@@ -40,24 +40,28 @@ def test_download(snapshotter, uploader, storage, tmpdir):
 
 
 def test_api_download(client, mocker):
-    url = "http://addr/result"
-    m = mocker.patch.object(utils, "http_request")
+    mocker.patch.object(utils, "http_request")
     response = client.post("/node/download")
     assert response.status_code == 422, response.json()
 
-    # Actual restoration is painful. So we trust above test_download to work,
-    # and pass empty list of files to be downloaded
-    req_json = {"result_url": url, "storage": "x", "state": {"root_globs": ["*"], "files": []}}
 
-    response = client.post("/node/download", json=req_json)
+def test_api_clear(client, mocker):
+    url = "http://addr/result"
+    m = mocker.patch.object(utils, "http_request")
+    # Actual restoration is painful. So we trust above test_download
+    # (and systest) to work, and pass empty list of files to be
+    # downloaded
+    req_json = {"result_url": url, "root_globs": ["*"]}
+
+    response = client.post("/node/clear", json=req_json)
     assert response.status_code == 409, response.json()
 
     response = client.post("/node/lock?locker=x&ttl=10")
     assert response.status_code == 200, response.json()
-    response = client.post("/node/download")
+    response = client.post("/node/clear")
     assert response.status_code == 422, response.json()
 
-    response = client.post("/node/download", json=req_json)
+    response = client.post("/node/clear", json=req_json)
     assert response.status_code == 200, response.json()
 
     # Decode the (result endpoint) response using the model


### PR DESCRIPTION
See commits for more details;

- astacus: Remove passing of SnapshotState in DownloadRequest
- coordinator: Add partial restore support
- coordinator: Add support for not doing anything if shutting down
- coordinator: request_from_nodes info instead of debug logging
- exceptions: Add RohmuException for 'got something wrong from rohmu'
- node: Handle FileExistsError in snapshot
- node: Add locking around use of Snapshotter
- utils: Removed use of too broad except in httpx_request
