### PR TITLE
m3placement: Moved to own module under common

### DIFF
--- a/astacus/common/m3placement.py
+++ b/astacus/common/m3placement.py
@@ -1,0 +1,98 @@
+"""
+
+Copyright (c) 2020 Aiven Ltd
+See LICENSE for details
+
+M3 placement handling code
+
+Note that this is used only by coordinator, but it may also be
+desirable to use it outside and due to that it is stand-alone module,
+as opposed to part of astacus.coordinator.plugins.m3db.
+
+"""
+
+from astacus.common.utils import AstacusModel
+from astacus.proto import m3_placement_pb2
+from pydantic import validator
+from typing import List
+
+MAXIMUM_PROTOBUF_STR_LENGTH = 127
+
+
+def non_empty_and_sane_length(value):
+    if len(value) == 0:
+        raise ValueError("Empty value is not supported")
+    if len(value) > MAXIMUM_PROTOBUF_STR_LENGTH:
+        raise ValueError("Large protobuf fields are not supported")
+    return value
+
+
+class M3PlacementNode(AstacusModel):
+    # In Aiven-internal case, most of these are redundant fields (we
+    # could derive node_id and hostname from endpoint); however, for
+    # generic case, we configure all of them (and expect them to be
+    # configured).
+
+    node_id: str
+    _validate_node_id = validator("node_id", allow_reuse=True)(non_empty_and_sane_length)
+
+    endpoint: str
+    _validate_endpoint = validator("endpoint", allow_reuse=True)(non_empty_and_sane_length)
+
+    hostname: str
+    _validate_hostname = validator("hostname", allow_reuse=True)(non_empty_and_sane_length)
+
+    # isolation_group: str # redundant - it is available from generic node snapshot result as az
+    # zone/weight: assumed to stay same
+
+
+class M3PlacementNodeReplacement(AstacusModel):
+    src_pnode: M3PlacementNode
+    dst_pnode: M3PlacementNode
+    dst_isolation_group: str = ""
+
+
+def rewrite_single_m3_placement_node(
+    placement, *, src_pnode: M3PlacementNode, dst_pnode: M3PlacementNode, dst_isolation_group=""
+):
+    """rewrite single m3 placement entry in-place in protobuf
+
+Relevant places ( see m3db
+src/cluster/generated/proto/placementpb/placement.proto which is
+copied to astacus/proto/m3_placement.proto )) :
+
+instance<str,Instance> map = 1, and then
+
+message Instance {
+  string id                 = 1;
+  string isolation_group    = 2;
+  string endpoint           = 5;
+  string hostname           = 8;
+}
+
+    """
+    instance = placement.instances[src_pnode.node_id]
+    # az may or may not be set; if not, keep original
+    if dst_isolation_group:
+        instance.isolation_group = dst_isolation_group
+    instance.endpoint = dst_pnode.endpoint
+    instance.hostname = dst_pnode.hostname
+
+    # Handle (potential) id change (bit painful as it is also map key)
+    instance.id = dst_pnode.node_id
+    del placement.instances[src_pnode.node_id]
+    placement.instances[dst_pnode.node_id].CopyFrom(instance)
+
+
+def rewrite_m3_placement_bytes(value: bytes, replacements: List[M3PlacementNodeReplacement]):
+    """rewrite whole binary m3 placement, with the set of node replacements"""
+    placement = m3_placement_pb2.Placement()
+    placement.ParseFromString(value)
+    for replacement in replacements:
+        rewrite_single_m3_placement_node(
+            placement,
+            src_pnode=replacement.src_pnode,
+            dst_isolation_group=replacement.dst_isolation_group,
+            dst_pnode=replacement.dst_pnode
+        )
+    return placement.SerializeToString()

--- a/astacus/coordinator/plugins/m3db.py
+++ b/astacus/coordinator/plugins/m3db.py
@@ -10,10 +10,8 @@ state is consistent.
 """
 
 from .etcd import ETCDBackupOpBase, ETCDConfiguration, ETCDDump, ETCDRestoreOpBase
-from astacus.common import exceptions, ipc
+from astacus.common import exceptions, ipc, m3placement
 from astacus.common.utils import AstacusModel
-from astacus.proto import m3_placement_pb2
-from pydantic import validator
 from typing import List, Optional
 
 import logging
@@ -25,44 +23,14 @@ class M3IncorrectPlacementNodesLengthException(exceptions.PermanentException):
     pass
 
 
-MAXIMUM_PROTOBUF_STR_LENGTH = 127
-
-
-def non_empty_and_sane_length(value):
-    if len(value) == 0:
-        raise ValueError("Empty value is not supported")
-    if len(value) > MAXIMUM_PROTOBUF_STR_LENGTH:
-        raise ValueError("Large protobuf fields are not supported")
-    return value
-
-
-class M3PlacementNode(AstacusModel):
-    # In Aiven-internal case, most of these are redundant fields (we
-    # could derive node_id and hostname from endpoint); however, for
-    # generic case, we configure all of them (and expect them to be
-    # configured).
-
-    node_id: str
-    _validate_node_id = validator("node_id", allow_reuse=True)(non_empty_and_sane_length)
-
-    endpoint: str
-    _validate_endpoint = validator("endpoint", allow_reuse=True)(non_empty_and_sane_length)
-
-    hostname: str
-    _validate_hostname = validator("hostname", allow_reuse=True)(non_empty_and_sane_length)
-
-    # isolation_group: str # redundant - it is available from generic node snapshot result as az
-    # zone/weight: assumed to stay same
-
-
 class M3DBConfiguration(ETCDConfiguration):
     environment: str
-    placement_nodes: List[M3PlacementNode]
+    placement_nodes: List[m3placement.M3PlacementNode]
 
 
 class M3DBManifest(AstacusModel):
     etcd: ETCDDump
-    placement_nodes: List[M3PlacementNode]
+    placement_nodes: List[m3placement.M3PlacementNode]
 
 
 def _validate_m3_config(o):
@@ -119,37 +87,6 @@ class M3DBBackupOp(ETCDBackupOpBase):
         return m3manifest
 
 
-def rewrite_single_m3_placement(placement, *, src_pnode: M3PlacementNode, dst_pnode: M3PlacementNode, dst_isolation_group):
-    """rewrite single m3 placement entry in-place in protobuf
-
-Relevant places ( see m3db
-src/cluster/generated/proto/placementpb/placement.proto which is
-copied to astacus/proto/m3_placement.proto )) :
-
-instance<str,Instance> map = 1, and then
-
-message Instance {
-  string id                 = 1;
-  string isolation_group    = 2;
-  string endpoint           = 5;
-  string hostname           = 8;
-}
-
-    """
-    instance = placement.instances[src_pnode.node_id]
-    # az may or may not be set; if not, keep original
-    if dst_isolation_group:
-        instance.isolation_group = dst_isolation_group
-    # Copy the rest of the fields
-    instance.endpoint = dst_pnode.endpoint
-    instance.hostname = dst_pnode.hostname
-
-    # Handle (potential) id change (bit painful as it is also map key)
-    instance.id = dst_pnode.node_id
-    del placement.instances[src_pnode.node_id]
-    placement.instances[dst_pnode.node_id].CopyFrom(instance)
-
-
 class M3DRestoreOp(ETCDRestoreOpBase):
     plugin = ipc.Plugin.m3db
     steps = [
@@ -167,18 +104,18 @@ class M3DRestoreOp(ETCDRestoreOpBase):
         return True
 
     def _rewrite_m3db_placement(self, key):
+        replacements = []
         node_to_backup_index = self._get_node_to_backup_index()
-        value = key.value_bytes
-
-        placement = m3_placement_pb2.Placement()
-        placement.ParseFromString(value)
-
         for idx, node, pnode in zip(node_to_backup_index, self.nodes, self.plugin_config.placement_nodes):
             if idx is None:
                 continue
             src_pnode = self.plugin_manifest.placement_nodes[idx]
-            rewrite_single_m3_placement(placement, src_pnode=src_pnode, dst_isolation_group=node.az, dst_pnode=pnode)
-        key.set_value_bytes(placement.SerializeToString())
+            replacements.append(
+                m3placement.M3PlacementNodeReplacement(src_pnode=src_pnode, dst_isolation_group=node.az, dst_pnode=pnode)
+            )
+        value = key.value_bytes
+        value = m3placement.rewrite_m3_placement_bytes(value, replacements)
+        key.set_value_bytes(value)
 
     async def step_rewrite_etcd(self):
         if self.req.partial_restore_nodes:

--- a/tests/unit/common/test_m3placement.py
+++ b/tests/unit/common/test_m3placement.py
@@ -1,0 +1,57 @@
+"""
+
+Copyright (c) 2020 Aiven Ltd
+See LICENSE for details
+
+Some tests of the m3 placement rewriter in common
+
+"""
+from astacus.common import m3placement
+from astacus.proto import m3_placement_pb2
+
+# What's in the (recorded, historic) placement plan
+src_pnode = m3placement.M3PlacementNode(
+    node_id="node-id1",
+    endpoint="endpoint1",
+    hostname="hostname1",
+)
+# What we want to replace it with
+dst_pnode = m3placement.M3PlacementNode(
+    node_id="node-id22",
+    endpoint="endpoint22",
+    hostname="hostname22",
+)
+
+
+def create_dummy_placement():
+    placement = m3_placement_pb2.Placement()
+    instance = placement.instances["node-id1"]
+    instance.id = "node-id1"
+    instance.endpoint = "endpoint1"
+    instance.hostname = "hostname1"
+    return placement
+
+
+def test_rewrite_single_m3_placement_node():
+    placement = create_dummy_placement()
+    m3placement.rewrite_single_m3_placement_node(
+        placement, src_pnode=src_pnode, dst_pnode=dst_pnode, dst_isolation_group="az22"
+    )
+    instance2 = placement.instances["node-id22"]
+    assert instance2.endpoint == "endpoint22"
+    assert instance2.hostname == "hostname22"
+    assert instance2.isolation_group == "az22"
+
+
+def test_rewrite_m3_placement_bytes():
+    value = create_dummy_placement().SerializeToString()
+    assert isinstance(value, bytes)
+    expected_bytes = [b"endpoint22", b"hostname22", b"az22"]
+    for expected in expected_bytes:
+        assert expected not in value
+    replacements = [
+        m3placement.M3PlacementNodeReplacement(src_pnode=src_pnode, dst_pnode=dst_pnode, dst_isolation_group="az22")
+    ]
+    value = m3placement.rewrite_m3_placement_bytes(value, replacements)
+    for expected in expected_bytes:
+        assert expected in value


### PR DESCRIPTION
This is mainly so that we can use it from elsewhere, and the
functionality is relatively isolated. The code itself should be only
used from coordinator's m3db plugin within astacus codebase.