### PR TITLE
ci: fix installing ubuntu dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build-dep-fedora:
 
 .PHONY: build-dep-ubuntu
 build-dep-ubuntu:
-	sudo apt-get install -y git libsnappy-dev python3-pip python3-psycopg2 protobuf-compiler
+	sudo sh -c 'apt-get update && apt-get install -y git libsnappy-dev python3-pip python3-psycopg2 protobuf-compiler'
 
 .PHONY: pylint
 pylint: $(GENERATED)


### PR DESCRIPTION
Github Workflow builds started failing due to `apt-get install` failure for not found packages. Fixed by running `apt-get update` before install.