### PR TITLE
storage: proxy support for google storage backend

### DIFF
--- a/astacus/common/rohmustorage.py
+++ b/astacus/common/rohmustorage.py
@@ -44,6 +44,24 @@ class RohmuModel(AstacusModel):
         use_enum_values = True
 
 
+class RohmuProxyType(str, Enum):
+    socks5 = "socks5"
+    http = "http"
+
+
+class RohmuProxyInfo(RohmuModel):
+    type: RohmuProxyType
+    host: str
+    port: int
+    user: Optional[str] = None
+    password: Optional[str] = Field(None, alias="pass")
+
+
+class RohmuProxyStorage(RohmuModel):
+    """Storage backend with support for optional socks5 or http proxy connections"""
+    proxy_info: Optional[RohmuProxyInfo] = None
+
+
 class RohmuLocalStorageConfig(RohmuModel):
     storage_type: Literal[RohmuStorageType.local]
     directory: DirectoryPath
@@ -69,7 +87,7 @@ class RohmuAzureStorageConfig(RohmuModel):
     azure_cloud: Optional[str] = None
 
 
-class RohmuGoogleStorageConfig(RohmuModel):
+class RohmuGoogleStorageConfig(RohmuProxyStorage):
     storage_type: Literal[RohmuStorageType.google]
     # rohmu.object_storage.google:GoogleTransfer.__init__ arguments
     project_id: str

--- a/examples/astacus-files-google.json
+++ b/examples/astacus-files-google.json
@@ -27,6 +27,38 @@
                 "prefix": "REDACTED",
                 "project_id": "REDACTED",
                 "storage_type": "google"
+            },
+            "x-proxy": {
+                "bucket_name": "REDACTED",
+                "credentials": {
+                    "token_uri": "https://accounts.google.com/o/oauth2/token",
+                    "type": "service_account"
+                },
+                "prefix": "REDACTED",
+                "project_id": "REDACTED",
+                "storage_type": "google",
+                "proxy_info": {
+                    "type": "socks5",
+                    "host": "localhost",
+                    "port": 1080,
+                    "user": "REDACTED",
+                    "pass": "REDACTED"
+                }
+            },
+            "x-proxy-no-userpass": {
+                "bucket_name": "REDACTED",
+                "credentials": {
+                    "token_uri": "https://accounts.google.com/o/oauth2/token",
+                    "type": "service_account"
+                },
+                "prefix": "REDACTED",
+                "project_id": "REDACTED",
+                "storage_type": "google",
+                "proxy_info": {
+                    "type": "socks5",
+                    "host": "localhost",
+                    "port": 1080
+                }
             }
         }
     },


### PR DESCRIPTION
Adds support for configuring rohmu storage with optional support for socks5 or http proxy connections. Rohmu supports proxying atm only for Google storage backend.