### PR TITLE
common: fix rohmu storage initialization

### DIFF
--- a/astacus/common/rohmustorage.py
+++ b/astacus/common/rohmustorage.py
@@ -225,7 +225,7 @@ class RohmuStorage(Storage):
             storage = self.config.default_storage
         self.storage_name = storage
         self.storage_config = self.config.storages[storage]
-        self.storage = rohmu.get_transfer(self.storage_config.dict())
+        self.storage = rohmu.get_transfer(self.storage_config.dict(by_alias=True, exclude_unset=True))
 
     def copy(self):
         return RohmuStorage(config=self.config, storage=self.storage_name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,5 +22,5 @@ install_requires =
 #  azure-mgmt-storage
 #  botocore
 # pghoard google
-#  google-api-python-client
-#  oauth2client
+  google-api-python-client
+  oauth2client


### PR DESCRIPTION
Rohmu storage transfer object was created from a dict that does not take Pydantic model aliases into account. Included also a test to verify that the transfer object gets properly populated proxy config.