### PR TITLE
models: add options to rohmu s3 storage model

### DIFF
--- a/astacus/common/rohmustorage.py
+++ b/astacus/common/rohmustorage.py
@@ -74,6 +74,10 @@ class RohmuS3StorageConfig(RohmuModel):
     bucket_name: str
     aws_access_key_id: Optional[str] = None
     aws_secret_access_key: Optional[str] = None
+    host: Optional[str] = None
+    port: Optional[int] = None
+    is_secure: Optional[bool] = False
+    is_verify_tls: Optional[bool] = False
     prefix: Optional[str] = None
     # Some more obscure options with defaults are omitted
 


### PR DESCRIPTION
The absence of these fields prevents from using pghoard's s3 driver with s3-compatible cloud storages.