### PR TITLE
clickhouse: avoid overloading server during ATTACH and SYNC

### DIFF
--- a/astacus/common/limiter.py
+++ b/astacus/common/limiter.py
@@ -1,0 +1,16 @@
+"""
+Copyright (c) 2021 Aiven Ltd
+See LICENSE for details
+"""
+from typing import Awaitable
+
+import asyncio
+
+
+class Limiter:
+    def __init__(self, limit: int):
+        self.semaphore = asyncio.Semaphore(limit)
+
+    async def run(self, awaitable: Awaitable) -> None:
+        async with self.semaphore:
+            await awaitable

--- a/astacus/coordinator/plugins/clickhouse/steps.py
+++ b/astacus/coordinator/plugins/clickhouse/steps.py
@@ -7,14 +7,18 @@ from .config import ClickHouseConfiguration, ReplicatedDatabaseSettings
 from .dependencies import access_entities_sorted_by_dependencies, tables_sorted_by_dependencies
 from .escaping import escape_for_file_name, unescape_from_file_name
 from .manifest import AccessEntity, ClickHouseManifest, ReplicatedDatabase, Table
-from .parts import check_parts_replication, distribute_parts_to_servers, get_frozen_parts_pattern, group_files_into_parts
+from .parts import (
+    check_parts_replication, distribute_parts_to_servers, get_frozen_parts_pattern, group_files_into_parts,
+    list_parts_to_attach
+)
 from .zookeeper import ChangeWatch, NodeExistsError, ZooKeeperClient
 from astacus.common import ipc
 from astacus.common.exceptions import TransientException
+from astacus.common.limiter import Limiter
 from astacus.coordinator.cluster import Cluster
 from astacus.coordinator.plugins.base import BackupManifestStep, SnapshotStep, Step, StepFailedError, StepsContext
 from pathlib import Path
-from typing import cast, Dict, List, Set, Tuple
+from typing import cast, Dict, List, Tuple
 
 import asyncio
 import dataclasses
@@ -414,22 +418,25 @@ class AttachMergeTreePartsStep(Step[None]):
     details.
     """
     clients: List[ClickHouseClient]
+    attach_timeout: float
+    max_concurrent_attach: int
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
         backup_manifest = context.get_result(BackupManifestStep)
         clickhouse_manifest = context.get_result(ClickHouseManifestStep)
         tasks = []
         tables_by_uuid = {table.uuid: table for table in clickhouse_manifest.tables}
+        limiter = Limiter(self.max_concurrent_attach)
         for client, snapshot_result in zip(self.clients, backup_manifest.snapshot_results):
-            parts_to_attach: Set[Tuple[str, str]] = set()
-            for snapshot_file in snapshot_result.state.files:
-                table_uuid = uuid.UUID(snapshot_file.relative_path.parts[2])
-                table = tables_by_uuid.get(table_uuid)
-                if table is not None:
-                    part_name = unescape_from_file_name(snapshot_file.relative_path.parts[4])
-                    parts_to_attach.add((table.escaped_sql_identifier, part_name))
-            for table_identifier, part_name in sorted(parts_to_attach):
-                tasks.append(client.execute(f"ALTER TABLE {table_identifier} ATTACH PART {escape_sql_string(part_name)}"))
+            for table_identifier, part_name in list_parts_to_attach(snapshot_result, tables_by_uuid):
+                tasks.append(
+                    limiter.run(
+                        client.execute(
+                            f"ALTER TABLE {table_identifier} ATTACH PART {escape_sql_string(part_name)}",
+                            timeout=self.attach_timeout,
+                        )
+                    )
+                )
         await asyncio.gather(*tasks)
 
 
@@ -441,11 +448,13 @@ class SyncReplicasStep(Step[None]):
     """
     clients: List[ClickHouseClient]
     sync_timeout: float
+    max_concurrent_sync: int
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
         manifest = context.get_result(ClickHouseManifestStep)
+        limiter = Limiter(self.max_concurrent_sync)
         tasks = [
-            client.execute(f"SYSTEM SYNC REPLICA {table.escaped_sql_identifier}", timeout=self.sync_timeout)
+            limiter.run(client.execute(f"SYSTEM SYNC REPLICA {table.escaped_sql_identifier}", timeout=self.sync_timeout))
             for table in manifest.tables
             for client in self.clients
             if table.is_replicated

--- a/tests/integration/coordinator/plugins/clickhouse/test_plugin.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_plugin.py
@@ -94,7 +94,7 @@ async def setup_cluster_content(clients: List[HttpClickHouseClient]) -> None:
         "ENGINE = MergeTree ORDER BY (thekey3) "
         "AS SELECT toInt32(thekey * 3) as thekey3 FROM default.merge_tree"
     )
-    await clients[0].execute("CREATE TABLE default.log  (thekey UInt32, thedata String)  ENGINE = Log")
+    await clients[0].execute("CREATE TABLE default.memory  (thekey UInt32, thedata String)  ENGINE = Memory")
     # This will be replicated between nodes
     await clients[0].execute("INSERT INTO default.replicated_merge_tree VALUES (123, 'foo')")
     await clients[1].execute("INSERT INTO default.replicated_merge_tree VALUES (456, 'bar')")
@@ -102,7 +102,7 @@ async def setup_cluster_content(clients: List[HttpClickHouseClient]) -> None:
     await clients[0].execute("INSERT INTO default.merge_tree VALUES (123, 'foo')")
     await clients[1].execute("INSERT INTO default.merge_tree VALUES (456, 'bar')")
     # This won't be backed up
-    await clients[0].execute("INSERT INTO default.log VALUES (123, 'foo')")
+    await clients[0].execute("INSERT INTO default.memory VALUES (123, 'foo')")
 
 
 async def setup_cluster_users(clients: List[HttpClickHouseClient]) -> None:
@@ -190,4 +190,4 @@ async def test_restores_connectivity_between_distributed_servers(restored_cluste
 async def test_does_not_restore_log_tables_data(restored_cluster: List[ClickHouseClient]) -> None:
     # We restored the table structure but not the data
     for client in restored_cluster:
-        assert await client.execute("SELECT thekey, thedata FROM default.log") == []
+        assert await client.execute("SELECT thekey, thedata FROM default.memory") == []

--- a/tests/unit/common/test_limiter.py
+++ b/tests/unit/common/test_limiter.py
@@ -1,0 +1,35 @@
+"""
+Copyright (c) 2021 Aiven Ltd
+See LICENSE for details
+"""
+
+from astacus.common.limiter import Limiter
+from typing import Sequence
+
+import asyncio
+import pytest
+
+
+@pytest.mark.parametrize(
+    "limit,expected_trace", [
+        (1, ["s1", "e1", "s2", "e2", "s3", "e3"]),
+        (2, ["s1", "s2", "e2", "s3", "e3", "e1"]),
+        (3, ["s1", "s2", "s3", "e2", "e3", "e1"]),
+    ]
+)
+@pytest.mark.asyncio
+async def test_limiter(limit: int, expected_trace: Sequence[str]) -> None:
+    trace = []
+
+    async def add_trace(start: str, sleep: float, stop: str):
+        trace.append(start)
+        await asyncio.sleep(sleep)
+        trace.append(stop)
+
+    limiter = Limiter(limit)
+    await asyncio.gather(
+        limiter.run(add_trace("s1", 0.1, "e1")),
+        limiter.run(add_trace("s2", 0.01, "e2")),
+        limiter.run(add_trace("s3", 0.03, "e3")),
+    )
+    assert trace == expected_trace


### PR DESCRIPTION
Increase timeout and add a concurrency limiter to avoid
issuing too many queries at once during ATTACH and SYNC
operations on large backups with many file