### PR TITLE
clickhouse: support non-utf-8 string

### DIFF
--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -135,16 +135,12 @@ class UploadManifestStep(Step[None]):
     """
     json_storage: AsyncJsonStorage
     plugin: ipc.Plugin
-    plugin_manifest_step: Optional[Type[Step[AstacusModel]]] = None
+    plugin_manifest_step: Optional[Type[Step[Dict]]] = None
     snapshot_step: Optional[Type[Step[List[ipc.SnapshotResult]]]] = SnapshotStep
     upload_step: Optional[Type[Step[List[ipc.SnapshotUploadResult]]]] = UploadBlocksStep
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
-        if self.plugin_manifest_step is None:
-            plugin_data = {}
-        else:
-            plugin_manifest = context.get_result(self.plugin_manifest_step)
-            plugin_data = plugin_manifest.dict()
+        plugin_data = context.get_result(self.plugin_manifest_step) if self.plugin_manifest_step else {}
         manifest = ipc.BackupManifest(
             attempt=context.attempt,
             start=context.attempt_start,

--- a/astacus/coordinator/plugins/clickhouse/dependencies.py
+++ b/astacus/coordinator/plugins/clickhouse/dependencies.py
@@ -47,10 +47,10 @@ def access_entities_sorted_by_dependencies(access_entities: List[AccessEntity]) 
     # This means we need to parse the `attach_query` of the entity to find the uuid of
     # other entities. This is unpleasant, but the quoting format of entity names and entity
     # uuids is different enough to not risk false matches.
-    clickhouse_id = re.compile(r"ID\('([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})'\)")
+    clickhouse_id = re.compile(rb"ID\('([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})'\)")
     for entity in access_entities:
         sorter.add(entity.uuid)
-        for uuid_str in clickhouse_id.findall(entity.attach_query):
-            sorter.add(entity.uuid, uuid.UUID(uuid_str))
+        for uuid_bytes in clickhouse_id.findall(entity.attach_query):
+            sorter.add(entity.uuid, uuid.UUID(uuid_bytes.decode()))
     sort_order = list(sorter.static_order())
     return sorted(access_entities, key=lambda e: sort_order.index(e.uuid))

--- a/astacus/coordinator/plugins/clickhouse/escaping.py
+++ b/astacus/coordinator/plugins/clickhouse/escaping.py
@@ -5,11 +5,22 @@ See LICENSE for details
 import re
 
 
+def escape_bytes_for_file_name(name_bytes: bytes) -> str:
+    # This is based on ClickHouse's escapeForFileName which is used internally to
+    # safely create both file and folders on disk and ZooKeeper node names.
+    return re.sub(rb"[^a-zA-Z0-9_]", _percent_encode_byte, name_bytes).decode()
+
+
 def escape_for_file_name(name: str) -> str:
     # This is based on ClickHouse's escapeForFileName which is used internally to
     # safely create both file and folders on disk and ZooKeeper node names.
     name_bytes = name.encode()
     return re.sub(rb"[^a-zA-Z0-9_]", _percent_encode_byte, name_bytes).decode()
+
+
+def unescape_from_file_name_to_bytes(encoded_name: str) -> bytes:
+    encoded_bytes = encoded_name.encode()
+    return re.sub(rb"%([0-9A-F][0-9A-F])", _percent_decode_byte, encoded_bytes)
 
 
 def unescape_from_file_name(encoded_name: str) -> str:

--- a/astacus/coordinator/plugins/clickhouse/escaping.py
+++ b/astacus/coordinator/plugins/clickhouse/escaping.py
@@ -5,27 +5,15 @@ See LICENSE for details
 import re
 
 
-def escape_bytes_for_file_name(name_bytes: bytes) -> str:
+def escape_for_file_name(name: bytes) -> str:
     # This is based on ClickHouse's escapeForFileName which is used internally to
     # safely create both file and folders on disk and ZooKeeper node names.
-    return re.sub(rb"[^a-zA-Z0-9_]", _percent_encode_byte, name_bytes).decode()
+    return re.sub(rb"[^a-zA-Z0-9_]", _percent_encode_byte, name).decode()
 
 
-def escape_for_file_name(name: str) -> str:
-    # This is based on ClickHouse's escapeForFileName which is used internally to
-    # safely create both file and folders on disk and ZooKeeper node names.
-    name_bytes = name.encode()
-    return re.sub(rb"[^a-zA-Z0-9_]", _percent_encode_byte, name_bytes).decode()
-
-
-def unescape_from_file_name_to_bytes(encoded_name: str) -> bytes:
+def unescape_from_file_name(encoded_name: str) -> bytes:
     encoded_bytes = encoded_name.encode()
     return re.sub(rb"%([0-9A-F][0-9A-F])", _percent_decode_byte, encoded_bytes)
-
-
-def unescape_from_file_name(encoded_name: str) -> str:
-    encoded_bytes = encoded_name.encode()
-    return re.sub(rb"%([0-9A-F][0-9A-F])", _percent_decode_byte, encoded_bytes).decode()
 
 
 def _percent_encode_byte(match: re.Match) -> bytes:

--- a/astacus/coordinator/plugins/clickhouse/manifest.py
+++ b/astacus/coordinator/plugins/clickhouse/manifest.py
@@ -7,6 +7,8 @@ from astacus.coordinator.plugins.clickhouse.client import escape_sql_identifier
 from typing import List, Tuple
 from uuid import UUID
 
+import base64
+
 
 class AccessEntity(AstacusModel):
     """
@@ -15,8 +17,8 @@ class AccessEntity(AstacusModel):
     """
     type: str
     uuid: UUID
-    name: str
-    attach_query: str
+    name: bytes
+    attach_query: bytes
 
 
 class ReplicatedDatabase(AstacusModel):

--- a/astacus/coordinator/plugins/clickhouse/parts.py
+++ b/astacus/coordinator/plugins/clickhouse/parts.py
@@ -144,18 +144,18 @@ def get_frozen_parts_pattern(freeze_name: str) -> str:
     """
     Returns the glob pattern inside ClickHouse data dir where frozen table parts are stored.
     """
-    escaped_freeze_name = escape_for_file_name(freeze_name)
+    escaped_freeze_name = escape_for_file_name(freeze_name.encode())
     return f"shadow/{escaped_freeze_name}/store/**/*"
 
 
 def list_parts_to_attach(
     snapshot_result: SnapshotResult,
     tables_by_uuid: Mapping[uuid.UUID, Table],
-) -> Sequence[Tuple[str, str]]:
+) -> Sequence[Tuple[str, bytes]]:
     """
     Returns a list of table identifiers and part names to attach from the snapshot.
     """
-    parts_to_attach: Set[Tuple[str, str]] = set()
+    parts_to_attach: Set[Tuple[str, bytes]] = set()
     for snapshot_file in snapshot_result.state.files:
         table_uuid = uuid.UUID(snapshot_file.relative_path.parts[2])
         table = tables_by_uuid.get(table_uuid)

--- a/astacus/coordinator/plugins/clickhouse/plugin.py
+++ b/astacus/coordinator/plugins/clickhouse/plugin.py
@@ -7,8 +7,8 @@ from .config import (
 )
 from .parts import get_frozen_parts_pattern
 from .steps import (
-    AttachMergeTreePartsStep, ClickHouseManifestStep, CreateClickHouseManifestStep, DistributeReplicatedPartsStep,
-    FreezeTablesStep, MoveFrozenPartsStep, RemoveFrozenTablesStep, RestoreAccessEntitiesStep, RestoreReplicatedDatabasesStep,
+    AttachMergeTreePartsStep, ClickHouseManifestStep, DistributeReplicatedPartsStep, FreezeTablesStep, MoveFrozenPartsStep,
+    PrepareClickHouseManifestStep, RemoveFrozenTablesStep, RestoreAccessEntitiesStep, RestoreReplicatedDatabasesStep,
     RetrieveAccessEntitiesStep, RetrieveDatabasesAndTablesStep, SyncReplicasStep, UnfreezeTablesStep, ValidateConfigStep
 )
 from astacus.common.ipc import Plugin, RestoreRequest
@@ -55,11 +55,11 @@ class ClickHousePlugin(CoordinatorPlugin):
             # Prepare the manifest for restore
             MoveFrozenPartsStep(freeze_name=self.freeze_name),
             DistributeReplicatedPartsStep(),
-            CreateClickHouseManifestStep(),
+            PrepareClickHouseManifestStep(),
             UploadManifestStep(
                 json_storage=context.json_storage,
                 plugin=Plugin.clickhouse,
-                plugin_manifest_step=CreateClickHouseManifestStep,
+                plugin_manifest_step=PrepareClickHouseManifestStep,
             ),
         ]
 

--- a/astacus/coordinator/plugins/clickhouse/steps.py
+++ b/astacus/coordinator/plugins/clickhouse/steps.py
@@ -5,7 +5,7 @@ See LICENSE for details
 from .client import ClickHouseClient, escape_sql_identifier, escape_sql_string
 from .config import ClickHouseConfiguration, ReplicatedDatabaseSettings
 from .dependencies import access_entities_sorted_by_dependencies, tables_sorted_by_dependencies
-from .escaping import escape_bytes_for_file_name, escape_for_file_name, unescape_from_file_name_to_bytes
+from .escaping import escape_for_file_name, unescape_from_file_name
 from .manifest import AccessEntity, ClickHouseManifest, ReplicatedDatabase, Table
 from .parts import (
     check_parts_replication, distribute_parts_to_servers, get_frozen_parts_pattern, group_files_into_parts,
@@ -17,6 +17,7 @@ from astacus.common.limiter import Limiter
 from astacus.coordinator.cluster import Cluster
 from astacus.coordinator.plugins.base import BackupManifestStep, SnapshotStep, Step, StepFailedError, StepsContext
 from astacus.coordinator.plugins.zookeeper import ChangeWatch, NodeExistsError, ZooKeeperClient
+from base64 import b64decode
 from pathlib import Path
 from typing import Any, cast, Dict, List, Tuple
 
@@ -30,10 +31,15 @@ logger = logging.getLogger(__name__)
 
 DatabasesAndTables = Tuple[List[ReplicatedDatabase], List[Table]]
 
-TABLES_LIST_QUERY = """SELECT
-    system.databases.name,
-    system.tables.name, system.tables.engine, system.tables.uuid, system.tables.create_table_query,
-    arrayZip(system.tables.dependencies_database, system.tables.dependencies_table)
+TABLES_LIST_QUERY = b"""SELECT
+    base64Encode(system.databases.name),
+    base64Encode(system.tables.name),
+    system.tables.engine,
+    system.tables.uuid,
+    base64Encode(system.tables.create_table_query),
+    arrayZip(
+        arrayMap(x -> base64Encode(x), system.tables.dependencies_database),
+        arrayMap(x -> base64Encode(x), system.tables.dependencies_table))
 FROM system.databases LEFT JOIN system.tables ON system.tables.database == system.databases.name
 WHERE
     system.databases.engine == 'Replicated'
@@ -94,7 +100,7 @@ class RetrieveAccessEntitiesStep(Step[List[AccessEntity]]):
                             AccessEntity(
                                 type=entity_type,
                                 uuid=entity_uuid,
-                                name=unescape_from_file_name_to_bytes(node_name),
+                                name=unescape_from_file_name(node_name),
                                 attach_query=attach_query_bytes,
                             )
                         )
@@ -126,27 +132,31 @@ class RetrieveDatabasesAndTablesStep(Step[DatabasesAndTables]):
         clickhouse_client = self.clients[0]
         # We fetch everything in a single query, we don't have to care about consistency within that step.
         # However, the schema could be modified between now and the freeze step.
-        databases: Dict[str, ReplicatedDatabase] = {}
+        databases: Dict[bytes, ReplicatedDatabase] = {}
         tables: List[Table] = []
         rows = await clickhouse_client.execute(TABLES_LIST_QUERY)
-        for db_name, table_name, table_engine, table_uuid, table_query, dependencies in rows:
+        for base64_db_name, base64_table_name, table_engine, table_uuid, base64_table_query, base64_dependencies in rows:
+            assert isinstance(base64_db_name, str)
+            assert isinstance(base64_table_name, str)
+            assert isinstance(base64_table_query, str)
+            assert isinstance(base64_dependencies, list)
+            db_name = b64decode(base64_db_name)
             if db_name not in databases:
-                assert isinstance(db_name, str)
                 databases[db_name] = ReplicatedDatabase(name=db_name)
             # Thanks to the LEFT JOIN, an empty database without table will still return a row.
             # Unlike standard SQL, the table properties will have a default value instead of NULL,
             # that's why we skip tables with an empty name.
             # We need these rows and the LEFT JOIN that makes them: we want to list all
             # Replicated databases, including those without any table.
-            if table_name != "":
+            if base64_table_name != "":
                 tables.append(
                     Table(
                         database=db_name,
-                        name=table_name,
+                        name=b64decode(base64_table_name),
                         engine=table_engine,
                         uuid=uuid.UUID(cast(str, table_uuid)),
-                        create_query=table_query,
-                        dependencies=dependencies,
+                        create_query=b64decode(base64_table_query),
+                        dependencies=[(b64decode(d), b64decode(t)) for d, t in base64_dependencies],
                     )
                 )
         databases_list = sorted(databases.values(), key=lambda d: d.name)
@@ -199,10 +209,10 @@ class FreezeUnfreezeTablesStepBase(Step[None]):
         for table in tables:
             if table.requires_freezing:
                 # We only run it on the first client because the `ALTER TABLE (UN)FREEZE` is replicated
-                await self.clients[0].execute(
+                await self.clients[0].execute((
                     f"ALTER TABLE {table.escaped_sql_identifier} "
-                    f"{self.operation} WITH NAME {escape_sql_string(self.freeze_name)}"
-                )
+                    f"{self.operation} WITH NAME {escape_sql_string(self.freeze_name.encode())}"
+                ).encode())
 
 
 @dataclasses.dataclass
@@ -269,7 +279,7 @@ class MoveFrozenPartsStep(Step[None]):
         # I do not like mutating an existing result, we should making this more visible
         # by returning a mutated copy and use that in other steps
         snapshot_results: List[ipc.SnapshotResult] = context.get_result(SnapshotStep)
-        escaped_freeze_name = escape_for_file_name(self.freeze_name)
+        escaped_freeze_name = escape_for_file_name(self.freeze_name.encode())
         shadow_store_path = "shadow", escaped_freeze_name, "store"
         for snapshot_result in snapshot_results:
             for snapshot_file in snapshot_result.state.files:
@@ -342,7 +352,7 @@ class RestoreReplicatedDatabasesStep(Step[None]):
         settings = [
             "{}={}".format(
                 setting_name,
-                escape_sql_string(value) if isinstance(value, str) else value,
+                escape_sql_string(value.encode()) if isinstance(value, str) else value,
             ) for setting_name, value in self.replicated_database_settings.dict().items() if value is not None
         ]
         settings_clause = " SETTINGS {}".format(", ".join(settings)) if settings else ""
@@ -353,19 +363,20 @@ class RestoreReplicatedDatabasesStep(Step[None]):
             # If we don't do that, then the recreated database on one node will recover data from
             # a node where the database wasn't recreated yet.
             for client in self.clients:
-                await client.execute(f"DROP DATABASE IF EXISTS {escape_sql_identifier(database.name)} SYNC")
+                await client.execute(f"DROP DATABASE IF EXISTS {escape_sql_identifier(database.name)} SYNC".encode())
             for client in self.clients:
-                await client.execute(
+                await client.execute((
                     f"CREATE DATABASE {escape_sql_identifier(database.name)} "
-                    f"ENGINE = Replicated({escape_sql_string(database_path)}, '{{shard}}', '{{replica}}'){settings_clause}"
-                )
+                    f"ENGINE = Replicated({escape_sql_string(database_path.encode())}, '{{shard}}', '{{replica}}')"
+                    f"{settings_clause}"
+                ).encode())
         # If any known table depends on an unknown table that was inside a non-replicated
         # database engine, then this will crash. See comment in `RetrieveReplicatedDatabasesStep`.
         for table in tables_sorted_by_dependencies(manifest.tables):
             # Materialized views creates both a table for the view itself and a table
             # with the .inner_id. prefix to store the data, we don't need to recreate
             # them manually. We will need to restore their data parts however.
-            if not table.name.startswith(".inner_id."):
+            if not table.name.startswith(b".inner_id."):
                 # Create on the first client and let replication do its thing
                 await self.clients[0].execute(table.create_query)
 
@@ -393,7 +404,7 @@ class RestoreAccessEntitiesStep(Step[None]):
         clickhouse_manifest = context.get_result(ClickHouseManifestStep)
         async with self.zookeeper_client.connect() as connection:
             for access_entity in access_entities_sorted_by_dependencies(clickhouse_manifest.access_entities):
-                escaped_entity_name = escape_bytes_for_file_name(access_entity.name)
+                escaped_entity_name = escape_for_file_name(access_entity.name)
                 entity_name_path = f"{self.access_entities_path}/{access_entity.type}/{escaped_entity_name}"
                 entity_path = f"{self.access_entities_path}/uuid/{access_entity.uuid}"
                 attach_query_bytes = access_entity.attach_query
@@ -436,7 +447,7 @@ class AttachMergeTreePartsStep(Step[None]):
                         execute_with_timeout(
                             client,
                             self.attach_timeout,
-                            f"ALTER TABLE {table_identifier} ATTACH PART {escape_sql_string(part_name)}",
+                            f"ALTER TABLE {table_identifier} ATTACH PART {escape_sql_string(part_name)}".encode(),
                         )
                     )
                 )
@@ -458,14 +469,16 @@ class SyncReplicasStep(Step[None]):
         limiter = Limiter(self.max_concurrent_sync)
         tasks = [
             limiter.run(
-                execute_with_timeout(client, self.sync_timeout, f"SYSTEM SYNC REPLICA {table.escaped_sql_identifier}")
+                execute_with_timeout(
+                    client, self.sync_timeout, f"SYSTEM SYNC REPLICA {table.escaped_sql_identifier}".encode()
+                )
             ) for table in manifest.tables for client in self.clients if table.is_replicated
         ]
         await asyncio.gather(*tasks)
 
 
-async def execute_with_timeout(client: ClickHouseClient, timeout: float, query: str) -> None:
+async def execute_with_timeout(client: ClickHouseClient, timeout: float, query: bytes) -> None:
     # we use a session because we can't use the SETTINGS clause with all types of queries
     session_id = secrets.token_hex()
-    await client.execute(f"SET receive_timeout={timeout}", session_id=session_id)
+    await client.execute(f"SET receive_timeout={timeout}".encode(), session_id=session_id)
     await client.execute(query, session_id=session_id, timeout=timeout)

--- a/astacus/coordinator/plugins/clickhouse/steps.py
+++ b/astacus/coordinator/plugins/clickhouse/steps.py
@@ -18,7 +18,7 @@ from astacus.coordinator.cluster import Cluster
 from astacus.coordinator.plugins.base import BackupManifestStep, SnapshotStep, Step, StepFailedError, StepsContext
 from astacus.coordinator.plugins.zookeeper import ChangeWatch, NodeExistsError, ZooKeeperClient
 from pathlib import Path
-from typing import cast, Dict, List, Tuple
+from typing import Any, cast, Dict, List, Tuple
 
 import asyncio
 import dataclasses
@@ -154,17 +154,17 @@ class RetrieveDatabasesAndTablesStep(Step[DatabasesAndTables]):
 
 
 @dataclasses.dataclass
-class CreateClickHouseManifestStep(Step[ClickHouseManifest]):
+class PrepareClickHouseManifestStep(Step[Dict[str, Any]]):
     """
-    Collects access entities, databases and tables from previous steps into a `ClickHouseManifest`.
+    Collects access entities, databases and tables from previous steps into an uploadable manifest.
     """
-    async def run_step(self, cluster: Cluster, context: StepsContext) -> ClickHouseManifest:
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> Dict[str, Any]:
         databases, tables = context.get_result(RetrieveDatabasesAndTablesStep)
         return ClickHouseManifest(
             access_entities=context.get_result(RetrieveAccessEntitiesStep),
             replicated_databases=databases,
             tables=tables,
-        )
+        ).dict()
 
 
 @dataclasses.dataclass

--- a/astacus/coordinator/plugins/flink/plugin.py
+++ b/astacus/coordinator/plugins/flink/plugin.py
@@ -10,7 +10,7 @@ from astacus.coordinator.plugins.base import (
     BackupManifestStep, BackupNameStep, CoordinatorPlugin, OperationContext, Step, UploadManifestStep
 )
 from astacus.coordinator.plugins.flink.steps import (
-    CreateFlinkManifestStep, FlinkManifestStep, RestoreDataStep, RetrieveDataStep
+    FlinkManifestStep, PrepareFlinkManifestStep, RestoreDataStep, RetrieveDataStep
 )
 from astacus.coordinator.plugins.zookeeper_config import get_zookeeper_client, ZooKeeperConfiguration
 from typing import List
@@ -28,11 +28,11 @@ class FlinkPlugin(CoordinatorPlugin):
         zookeeper_client = get_zookeeper_client(self.zookeeper)
         return [
             RetrieveDataStep(zookeeper_client=zookeeper_client, zookeeper_paths=self.zookeeper_paths),
-            CreateFlinkManifestStep(),
+            PrepareFlinkManifestStep(),
             UploadManifestStep(
                 json_storage=context.json_storage,
                 plugin=Plugin.flink,
-                plugin_manifest_step=CreateFlinkManifestStep,
+                plugin_manifest_step=PrepareFlinkManifestStep,
                 snapshot_step=None,
                 upload_step=None
             ),

--- a/astacus/coordinator/plugins/flink/steps.py
+++ b/astacus/coordinator/plugins/flink/steps.py
@@ -60,12 +60,12 @@ class RetrieveDataStep(Step[Dict[str, Any]]):
 
 
 @dataclasses.dataclass
-class CreateFlinkManifestStep(Step[FlinkManifest]):
+class PrepareFlinkManifestStep(Step[Dict[str, Any]]):
     """
-    Collects data from previous steps into a `FlinkManifest`.
+    Collects data from previous steps into an uploadable manifest.
     """
-    async def run_step(self, cluster: Cluster, context: StepsContext) -> FlinkManifest:
-        return FlinkManifest(data=context.get_result(RetrieveDataStep))
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> Dict[str, Any]:
+        return FlinkManifest(data=context.get_result(RetrieveDataStep)).dict()
 
 
 @dataclasses.dataclass

--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -16,7 +16,7 @@ docker==5.0.3
 # fastapi testclient needs this yet does not depend on it, gnn
 requests
 
-respx==0.11.2
+respx==0.16.3
 
 # convenience things that don't actually matter which version they are
 pip-outdated

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ zip_safe = False
 install_requires =
   PyYAML==5.4.1
   fastapi==0.54.2
-  httpx==0.13.3
+  httpx==0.16.1
   protobuf==3.12.4
   sentry-sdk==0.13.5
   tabulate==0.8.6

--- a/tests/integration/coordinator/plugins/clickhouse/conftest.py
+++ b/tests/integration/coordinator/plugins/clickhouse/conftest.py
@@ -210,6 +210,7 @@ def create_clickhouse_configs(
                     </logger>
                     <tcp_port>{tcp_port}</tcp_port>
                     <http_port>{http_port}</http_port>
+                    <interserver_http_host>localhost</interserver_http_host>
                     <interserver_http_port>{interserver_http_port}</interserver_http_port>
                     <zookeeper>
                         <node>

--- a/tests/integration/coordinator/plugins/clickhouse/test_client.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_client.py
@@ -17,14 +17,14 @@ pytestmark = [
 @pytest.mark.asyncio
 async def test_client_execute(clickhouse: Service) -> None:
     client = get_clickhouse_client(clickhouse)
-    response = await client.execute("SHOW DATABASES")
+    response = await client.execute(b"SHOW DATABASES")
     assert sorted(list(response)) == [["INFORMATION_SCHEMA"], ["default"], ["information_schema"], ["system"]]
 
 
 @pytest.mark.asyncio
 async def test_client_execute_on_system_database(clickhouse: Service) -> None:
     client = get_clickhouse_client(clickhouse)
-    response = await client.execute("SELECT currentDatabase()")
+    response = await client.execute(b"SELECT currentDatabase()")
     assert response == [["system"]]
 
 
@@ -34,7 +34,7 @@ async def test_client_execute_with_empty_response(clickhouse: Service) -> None:
     # an empty json dict and instead replies with an empty string.
     client = get_clickhouse_client(clickhouse)
     # This query should be harmless enough
-    response = await client.execute("SYSTEM DROP DNS CACHE")
+    response = await client.execute(b"SYSTEM DROP DNS CACHE")
     assert response == []
 
 
@@ -45,7 +45,7 @@ async def test_client_execute_bounded_connection_failure_time(ports: Ports) -> N
         clickhouse.process.kill()
         start_time = time.monotonic()
         with pytest.raises(ClickHouseClientQueryError):
-            await client.execute("SHOW DATABASES")
+            await client.execute(b"SHOW DATABASES")
         elapsed_time = time.monotonic() - start_time
         assert elapsed_time < 10.0
 
@@ -55,7 +55,7 @@ async def test_client_execute_bounded_query_time(clickhouse: Service) -> None:
     client = get_clickhouse_client(clickhouse, timeout=1.0)
     start_time = time.monotonic()
     with pytest.raises(ClickHouseClientQueryError):
-        await client.execute("SELECT 1,sleepEachRow(3)")
+        await client.execute(b"SELECT 1,sleepEachRow(3)")
     elapsed_time = time.monotonic() - start_time
     assert 1.0 <= elapsed_time < 3.0
 
@@ -66,6 +66,6 @@ async def test_client_execute_timeout_can_be_customized_per_query(clickhouse: Se
     start_time = time.monotonic()
     # The maximum sleep time in ClickHouse is 3 seconds
     with pytest.raises(ClickHouseClientQueryError):
-        await client.execute("SELECT 1,sleepEachRow(3)", timeout=1)
+        await client.execute(b"SELECT 1,sleepEachRow(3)", timeout=1)
     elapsed_time = time.monotonic() - start_time
     assert 1.0 <= elapsed_time < 3.0

--- a/tests/integration/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_steps.py
@@ -24,30 +24,43 @@ async def test_retrieve_tables(ports: Ports) -> None:
         async with create_clickhouse_cluster(zookeeper, ports, cluster_size=1) as clickhouse_cluster:
             clickhouse = clickhouse_cluster.services[0]
             client = get_clickhouse_client(clickhouse)
+            await client.execute((
+                "CREATE DATABASE `has_tablés` "
+                "ENGINE = Replicated('/clickhouse/databases/has_tables', '{shard}', '{replica}')"
+            ).encode())
             await client.execute(
-                "CREATE DATABASE has_tables ENGINE = Replicated('/clickhouse/databases/has_tables', '{shard}', '{replica}')"
+                b"CREATE DATABASE no_tables "
+                b"ENGINE = Replicated('/clickhouse/databases/no_tables', '{shard}', '{replica}')"
             )
             await client.execute(
-                "CREATE DATABASE no_tables ENGINE = Replicated('/clickhouse/databases/no_tables', '{shard}', '{replica}')"
+                b"CREATE DATABASE `bad\x80\x00db` "
+                b"ENGINE = Replicated('/clickhouse/databases/bad_db', '{shard}', '{replica}')"
             )
             await client.execute(
-                "CREATE TABLE has_tables.table_1 (thekey UInt32) ENGINE = ReplicatedMergeTree ORDER BY (thekey)"
+                ("CREATE TABLE `has_tablés`.`tablé_1` (thekey UInt32) "
+                 "ENGINE = ReplicatedMergeTree ORDER BY (thekey)").encode()
             )
             step = RetrieveDatabasesAndTablesStep(clients=[client])
             context = StepsContext()
             databases, tables = await step.run_step(Cluster(nodes=[]), context=context)
-            uuid_lines = list(await client.execute("SELECT uuid FROM system.tables where name = 'table_1' "))
+            uuid_lines = list(await client.execute("SELECT uuid FROM system.tables where name = 'tablé_1'".encode()))
             table_uuid = UUID(uuid_lines[0][0])
-            assert databases == [ReplicatedDatabase(name="has_tables"), ReplicatedDatabase(name="no_tables")]
+            assert databases == [
+                ReplicatedDatabase(name=b"bad\x80\x00db"),
+                ReplicatedDatabase(name="has_tablés".encode()),
+                ReplicatedDatabase(name=b"no_tables"),
+            ]
             assert tables == [
                 Table(
-                    database="has_tables",
-                    name="table_1",
+                    database="has_tablés".encode(),
+                    name="tablé_1".encode(),
                     engine="ReplicatedMergeTree",
                     uuid=table_uuid,
-                    create_query=f"CREATE TABLE has_tables.table_1 UUID '{str(table_uuid)}' (`thekey` UInt32) "
-                    f"ENGINE = ReplicatedMergeTree('/clickhouse/tables/{str(table_uuid)}/{{shard}}', '{{replica}}') "
-                    f"ORDER BY thekey SETTINGS index_granularity = 8192",
+                    create_query=(
+                        f"CREATE TABLE `has_tablés`.`tablé_1` UUID '{str(table_uuid)}' (`thekey` UInt32) "
+                        f"ENGINE = ReplicatedMergeTree('/clickhouse/tables/{str(table_uuid)}/{{shard}}', '{{replica}}') "
+                        f"ORDER BY thekey SETTINGS index_granularity = 8192"
+                    ).encode(),
                     dependencies=[]
-                )
+                ),
             ]

--- a/tests/unit/coordinator/plugins/clickhouse/test_client.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_client.py
@@ -27,11 +27,7 @@ async def test_successful_execute_returns_rows() -> None:
             "rows": 2,
             "rows_before_limit_at_least": 2
         }
-        respx.post(
-            "http://example.org:9000?query=SHOW+DATABASES&wait_end_of_query=1",
-            content=json.dumps(content),
-            content_type="application/json"
-        )
+        respx.post("http://example.org:9000?query=SHOW+DATABASES&wait_end_of_query=1").respond(json=content)
         response = await client.execute("SHOW DATABASES")
     assert response == [["system"], ["defaultdb"]]
 
@@ -40,7 +36,7 @@ async def test_successful_execute_returns_rows() -> None:
 async def test_failing_execute_raises_an_exception() -> None:
     client = HttpClickHouseClient(host="example.org", port=9000)
     with respx.mock:
-        respx.post("http://example.org:9000?query=SHOW+DATABASES&wait_end_of_query=1", status_code=400)
+        respx.post("http://example.org:9000?query=SHOW+DATABASES&wait_end_of_query=1").respond(status_code=400)
         with pytest.raises(ClickHouseClientQueryError):
             await client.execute("SHOW DATABASES")
 
@@ -49,7 +45,7 @@ async def test_failing_execute_raises_an_exception() -> None:
 async def test_sends_authentication_headers() -> None:
     client = HttpClickHouseClient(host="example.org", port=9000, username="user", password="password")
     with respx.mock:
-        respx.post("http://example.org:9000?query=SELECT+1+LIMIT+0&wait_end_of_query=1", content="")
+        respx.post("http://example.org:9000?query=SHOW+DATABASES&wait_end_of_query=1").respond(content="")
         await client.execute("SELECT 1 LIMIT 0")
         request = respx.calls[0][0]
         assert request.headers["x-clickhouse-user"] == "user"

--- a/tests/unit/coordinator/plugins/clickhouse/test_client.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_client.py
@@ -6,7 +6,6 @@ from astacus.coordinator.plugins.clickhouse.client import (
     ClickHouseClientQueryError, escape_sql_identifier, HttpClickHouseClient
 )
 
-import json
 import pytest
 import respx
 
@@ -27,8 +26,8 @@ async def test_successful_execute_returns_rows() -> None:
             "rows": 2,
             "rows_before_limit_at_least": 2
         }
-        respx.post("http://example.org:9000?query=SHOW+DATABASES&wait_end_of_query=1").respond(json=content)
-        response = await client.execute("SHOW DATABASES")
+        respx.post("http://example.org:9000?wait_end_of_query=1").respond(json=content)
+        response = await client.execute(b"SHOW DATABASES")
     assert response == [["system"], ["defaultdb"]]
 
 
@@ -36,23 +35,42 @@ async def test_successful_execute_returns_rows() -> None:
 async def test_failing_execute_raises_an_exception() -> None:
     client = HttpClickHouseClient(host="example.org", port=9000)
     with respx.mock:
-        respx.post("http://example.org:9000?query=SHOW+DATABASES&wait_end_of_query=1").respond(status_code=400)
+        respx.post("http://example.org:9000?wait_end_of_query=1").respond(status_code=400)
         with pytest.raises(ClickHouseClientQueryError):
-            await client.execute("SHOW DATABASES")
+            await client.execute(b"SHOW DATABASES")
 
 
 @pytest.mark.asyncio
 async def test_sends_authentication_headers() -> None:
     client = HttpClickHouseClient(host="example.org", port=9000, username="user", password="password")
     with respx.mock:
-        respx.post("http://example.org:9000?query=SHOW+DATABASES&wait_end_of_query=1").respond(content="")
-        await client.execute("SELECT 1 LIMIT 0")
+        respx.post("http://example.org:9000?wait_end_of_query=1").respond(content="")
+        await client.execute(b"SELECT 1 LIMIT 0")
         request = respx.calls[0][0]
         assert request.headers["x-clickhouse-user"] == "user"
         assert request.headers["x-clickhouse-key"] == "password"
 
 
-def test_escape_identifier() -> None:
-    assert escape_sql_identifier("foo") == "`foo`"
-    assert escape_sql_identifier("fo`o") == "`fo\\`o`"
-    assert escape_sql_identifier("fo\\o") == "`fo\\\\o`"
+def test_escape_sql_identifier() -> None:
+    assert escape_sql_identifier(b"foo") == "`foo`"
+    assert escape_sql_identifier(b"fo\\o") == "`fo\\\\o`"
+    assert escape_sql_identifier(b"fo`o") == "`fo\\`o`"
+
+
+def test_escape_sql_identifier_named_escaped() -> None:
+    assert escape_sql_identifier(b"fo\bo") == "`fo\\bo`"
+    assert escape_sql_identifier(b"fo\fo") == "`fo\\fo`"
+    assert escape_sql_identifier(b"fo\ro") == "`fo\\ro`"
+    assert escape_sql_identifier(b"fo\no") == "`fo\\no`"
+    assert escape_sql_identifier(b"fo\to") == "`fo\\to`"
+    assert escape_sql_identifier(b"fo\0o") == "`fo\\0o`"
+
+
+def test_escape_sql_identifier_high_bytes() -> None:
+    assert escape_sql_identifier(bytes((0x7E, ))) == "`~`"
+    for high_byte in range(0x7F, 0x100):
+        assert escape_sql_identifier(bytes((high_byte, ))) == f"`\\x{high_byte:02x}`"
+
+
+def test_escape_sql_identifier_utf8() -> None:
+    assert escape_sql_identifier("éléphant".encode()) == "`\\xc3\\xa9l\\xc3\\xa9phant`"

--- a/tests/unit/coordinator/plugins/clickhouse/test_dependencies.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_dependencies.py
@@ -65,16 +65,16 @@ def test_access_entities_sorted_by_dependencies() -> None:
     a1 = AccessEntity(
         type="P",
         uuid=uuid.UUID("00000000-abcd-0000-0000-000000000001"),
-        name="a1",
-        attach_query="""
+        name=b"a1",
+        attach_query=b"""
             ATTACH ROW POLICY a1 TO ID('00000000-abcd-0000-0000-000000000003'));
         """,
     )
     a2 = AccessEntity(
         type="R",
         uuid=uuid.UUID("00000000-abcd-0000-0000-000000000002"),
-        name="a2",
-        attach_query="""
+        name=b"a2",
+        attach_query=b"""
             ATTACH ROLE a2;
             ATTACH GRANT ID('00000000-abcd-0000-0000-000000000004') to a2;
         """,
@@ -82,15 +82,15 @@ def test_access_entities_sorted_by_dependencies() -> None:
     a3 = AccessEntity(
         type="U",
         uuid=uuid.UUID("00000000-abcd-0000-0000-000000000003"),
-        name="a3",
-        attach_query="""
+        name=b"a3",
+        attach_query=b"""
             ATTACH USER a3;
             ATTACH GRANT ID('00000000-abcd-0000-0000-000000000002') to a3;
             ATTACH GRANT ID('00000000-abcd-0000-0000-000000000004') to a3;
         """,
     )
     a4 = AccessEntity(
-        type="R", uuid=uuid.UUID("00000000-0000-abcd-0000-000000000004"), name="a4", attach_query="ATTACH ROLE a4"
+        type="R", uuid=uuid.UUID("00000000-0000-abcd-0000-000000000004"), name=b"a4", attach_query=b"ATTACH ROLE a4"
     )
     assert access_entities_sorted_by_dependencies([a1, a2, a3, a4]) == [a4, a2, a3, a1]
 
@@ -105,8 +105,8 @@ def test_dangling_access_entities_doesnt_crash() -> None:
     a1 = AccessEntity(
         type="P",
         uuid=uuid.UUID("00000000-abcd-0000-0000-000000000001"),
-        name="a1",
-        attach_query="""
+        name=b"a1",
+        attach_query=b"""
             ATTACH ROW POLICY a1 TO ID('00000000-abcd-0000-0000-000000000003'));
         """,
     )

--- a/tests/unit/coordinator/plugins/clickhouse/test_escaping.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_escaping.py
@@ -11,26 +11,23 @@ pytestmark = [pytest.mark.clickhouse]
 
 
 def test_escape_for_file_name_keeps_alphanumeric_and_underscore() -> None:
-    assert escape_for_file_name("cat") == "cat"
-    assert escape_for_file_name("LARGE_CAT") == "LARGE_CAT"
-    assert escape_for_file_name("cat56") == "cat56"
+    assert escape_for_file_name(b"cat") == "cat"
+    assert escape_for_file_name(b"LARGE_CAT") == "LARGE_CAT"
+    assert escape_for_file_name(b"cat56") == "cat56"
 
 
 def test_escape_for_file_name_escapes_with_uppercase_percent_encoding() -> None:
     # A few readable samples
-    assert escape_for_file_name("cat/tabby") == "cat%2Ftabby"
-    assert escape_for_file_name("cat/spotted_tabby") == "cat%2Fspotted_tabby"
-    assert escape_for_file_name("cat/tortoise-shell") == "cat%2Ftortoise%2Dshell"
+    assert escape_for_file_name(b"cat/tabby") == "cat%2Ftabby"
+    assert escape_for_file_name(b"cat/spotted_tabby") == "cat%2Fspotted_tabby"
+    assert escape_for_file_name(b"cat/tortoise-shell") == "cat%2Ftortoise%2Dshell"
+    assert escape_for_file_name("cat/câlicö".encode()) == "cat%2Fc%C3%A2lic%C3%B6"
     # An exhaustive scan of the single-byte UTF-8 (include all control characters)
     for byte_char in range(0, 128):
-        char = byte_char.to_bytes(1, "little").decode()
-        if not re.match(r"[a-zA-Z0-9_]", char):
+        char = byte_char.to_bytes(1, "little")
+        if not re.match(rb"[a-zA-Z0-9_]", char):
             assert escape_for_file_name(char) == f"%{byte_char:02X}"
 
 
-def test_escape_for_file_name_encodes_as_utf8_before_escaping() -> None:
-    assert escape_for_file_name("cat/câlicö") == "cat%2Fc%C3%A2lic%C3%B6"
-
-
 def test_unescape_from_file_name() -> None:
-    assert unescape_from_file_name("cat%2Fc%C3%A2lic%C3%B6") == "cat/câlicö"
+    assert unescape_from_file_name("cat%2Fc%C3%A2lic%C3%B6") == "cat/câlicö".encode()

--- a/tests/unit/coordinator/plugins/clickhouse/test_parts.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_parts.py
@@ -237,22 +237,22 @@ def test_list_parts_to_attach() -> None:
     parts_to_attach = list_parts_to_attach(
         SnapshotResult(state=SnapshotState(files=TABLE_1_PART_1 + TABLE_1_PART_2)), {
             T1_UUID: Table(
-                database="default",
-                name="table_1",
+                database=b"default",
+                name=b"table_1",
                 engine="ReplicatedMergeTree",
                 uuid=T1_UUID,
-                create_query="CREATE TABLE ..."
+                create_query=b"CREATE TABLE ..."
             ),
             T2_UUID: Table(
-                database="default",
-                name="table_2",
+                database=b"default",
+                name=b"table_2",
                 engine="ReplicatedMergeTree",
                 uuid=T2_UUID,
-                create_query="CREATE TABLE ..."
+                create_query=b"CREATE TABLE ..."
             )
         }
     )
     assert parts_to_attach == [
-        ('`default`.`table_1`', 'all_0_0_0'),
-        ('`default`.`table_1`', 'all_1_1_0'),
+        ('`default`.`table_1`', b'all_0_0_0'),
+        ('`default`.`table_1`', b'all_1_1_0'),
     ]

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -167,7 +167,6 @@ class TrappedZooKeeperClient(FakeZooKeeperClient):
     """
     A fake ZooKeeper client with a trap: it will inject a concurrent write after a few reads.
     """
-
     def __init__(self) -> None:
         super().__init__()
         self.calls_until_failure: Optional[int] = None
@@ -448,7 +447,8 @@ async def test_parse_clickhouse_manifest() -> None:
                     "name": "t1",
                     "engine": "MergeTree",
                     "uuid": "00000000-0000-0000-0000-000000000004",
-                    "create_query": "CREATE ..."
+                    "create_query": "CREATE ...",
+                    "dependencies": [],
                 }]
             }
         )

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -276,14 +276,14 @@ async def test_remove_frozen_tables_step() -> None:
     step = RemoveFrozenTablesStep(freeze_name="some-thing+special")
     cluster = Cluster(nodes=[CoordinatorNode(url="http://node1/node"), CoordinatorNode(url="http://node2/node")])
     with respx.mock:
-        respx.post(
-            "http://node1/node/clear", content=Op.StartResult(op_id=123, status_url="http://node1/clear/123").jsondict()
+        respx.post("http://node1/node/clear").respond(
+            json=Op.StartResult(op_id=123, status_url="http://node1/clear/123").jsondict()
         )
-        respx.post(
-            "http://node2/node/clear", content=Op.StartResult(op_id=456, status_url="http://node2/clear/456").jsondict()
+        respx.post("http://node2/node/clear").respond(
+            json=Op.StartResult(op_id=456, status_url="http://node2/clear/456").jsondict()
         )
-        respx.get("http://node1/clear/123", content=NodeResult(progress=Progress(final=True)).jsondict())
-        respx.get("http://node2/clear/456", content=NodeResult(progress=Progress(final=True)).jsondict())
+        respx.get("http://node1/clear/123").respond(json=NodeResult(progress=Progress(final=True)).jsondict())
+        respx.get("http://node2/clear/456").respond(json=NodeResult(progress=Progress(final=True)).jsondict())
         try:
             await step.run_step(cluster, StepsContext())
         finally:

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -13,8 +13,8 @@ from astacus.coordinator.plugins.clickhouse.client import ClickHouseClient, Stub
 from astacus.coordinator.plugins.clickhouse.config import ClickHouseConfiguration, ClickHouseNode, ReplicatedDatabaseSettings
 from astacus.coordinator.plugins.clickhouse.manifest import AccessEntity, ClickHouseManifest, ReplicatedDatabase, Table
 from astacus.coordinator.plugins.clickhouse.steps import (
-    AttachMergeTreePartsStep, ClickHouseManifestStep, CreateClickHouseManifestStep, DistributeReplicatedPartsStep,
-    FreezeTablesStep, RemoveFrozenTablesStep, RestoreAccessEntitiesStep, RestoreReplicatedDatabasesStep,
+    AttachMergeTreePartsStep, ClickHouseManifestStep, DistributeReplicatedPartsStep, FreezeTablesStep,
+    PrepareClickHouseManifestStep, RemoveFrozenTablesStep, RestoreAccessEntitiesStep, RestoreReplicatedDatabasesStep,
     RetrieveAccessEntitiesStep, RetrieveDatabasesAndTablesStep, SyncReplicasStep, TABLES_LIST_QUERY, UnfreezeTablesStep,
     ValidateConfigStep
 )
@@ -243,7 +243,7 @@ async def test_retrieve_tables_without_any_table() -> None:
 
 @pytest.mark.asyncio
 async def test_create_clickhouse_manifest() -> None:
-    step = CreateClickHouseManifestStep()
+    step = PrepareClickHouseManifestStep()
     context = StepsContext()
     context.set_result(RetrieveAccessEntitiesStep, SAMPLE_ENTITIES)
     context.set_result(RetrieveDatabasesAndTablesStep, (SAMPLE_DATABASES, SAMPLE_TABLES))

--- a/tests/unit/coordinator/plugins/test_m3db.py
+++ b/tests/unit/coordinator/plugins/test_m3db.py
@@ -125,9 +125,8 @@ async def test_m3_backup(coordinator: Coordinator, plugin: M3DBPlugin, etcd_clie
     context = StepsContext()
     with respx.mock:
         op.state.shutting_down = fail_at == 0
-        respx.post(
-            "http://dummy/etcd/kv/range",
-            content={"kvs": [
+        respx.post("http://dummy/etcd/kv/range").respond(
+            json={"kvs": [
                 {
                     "key": KEY1_B64,
                     "value": VALUE1_B64
@@ -183,6 +182,6 @@ async def test_m3_restore(coordinator: Coordinator, plugin: M3DBPlugin, etcd_cli
     fail_at = rt.fail_at
     with respx.mock:
         op.state.shutting_down = fail_at == 0
-        respx.post("http://dummy/etcd/kv/deleterange", content={"ok": True}, status_code=200 if fail_at != 1 else 500)
-        respx.post("http://dummy/etcd/kv/put", content={"ok": True}, status_code=200 if fail_at != 2 else 500)
+        respx.post("http://dummy/etcd/kv/deleterange").respond(json={"ok": True}, status_code=200 if fail_at != 1 else 500)
+        respx.post("http://dummy/etcd/kv/put").respond(json={"ok": True}, status_code=200 if fail_at != 2 else 500)
         assert await op.try_run(op.get_cluster(), context) == (fail_at is None)

--- a/tests/unit/coordinator/plugins/test_m3db.py
+++ b/tests/unit/coordinator/plugins/test_m3db.py
@@ -15,7 +15,7 @@ from astacus.coordinator.coordinator import Coordinator, SteppedCoordinatorOp
 from astacus.coordinator.plugins import m3db
 from astacus.coordinator.plugins.base import BackupManifestStep, StepsContext
 from astacus.coordinator.plugins.m3db import (
-    CreateM3ManifestStep, get_etcd_prefixes, InitStep, M3DBPlugin, RestoreEtcdStep, RetrieveEtcdAgainStep, RetrieveEtcdStep,
+    get_etcd_prefixes, InitStep, M3DBPlugin, PrepareM3ManifestStep, RestoreEtcdStep, RetrieveEtcdAgainStep, RetrieveEtcdStep,
     RewriteEtcdStep
 )
 from astacus.coordinator.state import CoordinatorState
@@ -119,7 +119,7 @@ async def test_m3_backup(coordinator: Coordinator, plugin: M3DBPlugin, etcd_clie
             InitStep(placement_nodes=plugin.placement_nodes),
             RetrieveEtcdStep(etcd_client=etcd_client, etcd_prefixes=etcd_prefixes),
             RetrieveEtcdAgainStep(etcd_client=etcd_client, etcd_prefixes=etcd_prefixes),
-            CreateM3ManifestStep(placement_nodes=plugin.placement_nodes),
+            PrepareM3ManifestStep(placement_nodes=plugin.placement_nodes),
         ]
     )
     context = StepsContext()
@@ -142,7 +142,7 @@ async def test_m3_backup(coordinator: Coordinator, plugin: M3DBPlugin, etcd_clie
         assert await op.try_run(op.get_cluster(), context) == (fail_at is None)
     if fail_at is not None:
         return
-    assert context.get_result(CreateM3ManifestStep) == PLUGIN_DATA
+    assert context.get_result(PrepareM3ManifestStep) == PLUGIN_DATA
 
 
 @dataclass

--- a/tests/unit/coordinator/test_cleanup.py
+++ b/tests/unit/coordinator/test_cleanup.py
@@ -21,9 +21,9 @@ def _run(*, client, populated_mstorage, app, fail_at=None, retention, exp_jsons,
     nodes = app.state.coordinator_config.nodes
     with respx.mock:
         for node in nodes:
-            respx.post(f"{node.url}/unlock?locker=x&ttl=0", content={"locked": False})
+            respx.post(f"{node.url}/unlock?locker=x&ttl=0").respond(json={"locked": False})
             # Failure point 1: Lock fails
-            respx.post(f"{node.url}/lock?locker=x&ttl=60", content={"locked": fail_at != 1})
+            respx.post(f"{node.url}/lock?locker=x&ttl=60").respond(json={"locked": fail_at != 1})
         response = client.post("/cleanup")
         if fail_at == 1:
             # Cluster lock failure is immediate

--- a/tests/unit/coordinator/test_lock.py
+++ b/tests/unit/coordinator/test_lock.py
@@ -39,7 +39,7 @@ def test_lock_ok(app, client):
     nodes = app.state.coordinator_config.nodes
     with respx.mock:
         for node in nodes:
-            respx.post(f"{node.url}/lock?locker=z&ttl=60", content={"locked": True})
+            respx.post(f"{node.url}/lock?locker=z&ttl=60").respond(json={"locked": True})
         response = client.post("/lock?locker=z")
         assert response.status_code == 200, response.json()
 
@@ -54,8 +54,8 @@ def test_lock_onefail(app, client):
     nodes = app.state.coordinator_config.nodes
     with respx.mock:
         for i, node in enumerate(nodes):
-            respx.post(f"{node.url}/lock?locker=z&ttl=60", content={"locked": i == 0})
-            respx.post(f"{node.url}/unlock?locker=z", content=None)
+            respx.post(f"{node.url}/lock?locker=z&ttl=60").respond(json={"locked": i == 0})
+            respx.post(f"{node.url}/unlock?locker=z").respond(content=None)
         with patch.object(StatsClient, "increase", return_value=None) as mock_stats_increase:
             response = client.post("/lock?locker=z")
             assert response.status_code == 200, response.json()


### PR DESCRIPTION
ClickHouse strings are byte strings and can contain any byte sequence,
including ones that cannot be decoded as UTF-8 or serialized in JSON.

This is true for database names, table names, access entities
and all the queries necessary to create these database objects.