### PR TITLE
fix SnapshotResult.state backward compatibility

### DIFF
--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -121,7 +121,7 @@ class SnapshotResult(NodeResult):
     end: Optional[datetime]
 
     # should be passed opaquely to restore
-    state: SnapshotState = Field(default_factory=SnapshotState)
+    state: Optional[SnapshotState] = Field(default_factory=SnapshotState)
 
     # Summary data for manifest use
     files: int = 0

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -213,17 +213,20 @@ class RestoreStep(Step[List[ipc.NodeResult]]):
         for node, backup_index in zip(cluster.nodes, node_to_backup_index):
             if backup_index is not None:
                 # Restore whatever was backed up
+                snapshot_result = snapshot_results[backup_index]
+                assert snapshot_result.state is not None
                 node_request: ipc.NodeRequest = ipc.SnapshotDownloadRequest(
                     storage=self.storage_name,
                     backup_name=backup_name,
                     snapshot_index=backup_index,
-                    root_globs=snapshot_results[backup_index].state.root_globs,
+                    root_globs=snapshot_result.state.root_globs,
                 )
                 op = "download"
             elif self.partial_restore_nodes:
                 # If partial restore, do not clear other nodes
                 continue
             else:
+                assert snapshot_results[0].state is not None
                 node_request = ipc.SnapshotClearRequest(root_globs=snapshot_results[0].state.root_globs)
                 op = "clear"
             start_result = await cluster.request_from_nodes(

--- a/astacus/coordinator/plugins/clickhouse/parts.py
+++ b/astacus/coordinator/plugins/clickhouse/parts.py
@@ -156,6 +156,7 @@ def list_parts_to_attach(
     Returns a list of table identifiers and part names to attach from the snapshot.
     """
     parts_to_attach: Set[Tuple[str, bytes]] = set()
+    assert snapshot_result.state is not None
     for snapshot_file in snapshot_result.state.files:
         table_uuid = uuid.UUID(snapshot_file.relative_path.parts[2])
         table = tables_by_uuid.get(table_uuid)


### PR DESCRIPTION
This value can be `null`/`None` when received from a node running the
code from before this change: https://github.com/aiven/astacus/commit/d92e18713b0284cceb62b6bdf0e5cb54ae80c75c

This only happened at the very beginning of a `SnapshotOp`,
when a node can return the value from `SnapshotOp.create_result()`
before the `state` is set in `SnapshotOp.snapshot()`.

This is a partial reversal, which allows the `None` value but stops
generating it.

After all nodes of a cluster are running code newer than the
previously mentioned commit, we will be able to remove the `Optional`
and all the asserts safely.