### PR TITLE
common: add azure service principal auth support

### DIFF
--- a/astacus/common/rohmustorage.py
+++ b/astacus/common/rohmustorage.py
@@ -82,11 +82,22 @@ class RohmuS3StorageConfig(RohmuModel):
     # Some more obscure options with defaults are omitted
 
 
+class RohmuAzureServicePrincipalCredentials(RohmuModel):
+    client_id: str
+    secret: str
+
+
+class RohmuAzureServicePrincipalConfig(RohmuModel):
+    client_credentials: RohmuAzureServicePrincipalCredentials
+    tenant_id: str
+
+
 class RohmuAzureStorageConfig(RohmuModel):
     storage_type: Literal[RohmuStorageType.azure]
     account_name: str
-    account_key: str
     bucket_name: str
+    account_key: Optional[str] = None
+    client_config: Optional[RohmuAzureServicePrincipalConfig] = None
     prefix: Optional[str] = None
     azure_cloud: Optional[str] = None
 


### PR DESCRIPTION
Previous config only allowed for authentication via storage_account name and key, which provides access to all resources in a storage_account. This PR adjusts the schema validation for the config to allow for authentication via service principal (see [Azure docs](https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/service-accounts-principal)). This approach provides granular permissions to be set at the container/blob levels. The service principal authentication itself is [being implemented in pghoard](https://github.com/aiven/pghoard/pull/509), which uses the config to build the AzureTransfer client to perform/restore backups. 