### PR TITLE
common: use sas_token for azure auth

### DIFF
--- a/astacus/common/rohmustorage.py
+++ b/astacus/common/rohmustorage.py
@@ -84,22 +84,12 @@ class RohmuS3StorageConfig(RohmuModel):
     # Some more obscure options with defaults are omitted
 
 
-class RohmuAzureServicePrincipalCredentials(RohmuModel):
-    client_id: str
-    secret: str
-
-
-class RohmuAzureServicePrincipalConfig(RohmuModel):
-    client_credentials: RohmuAzureServicePrincipalCredentials
-    tenant_id: str
-
-
 class RohmuAzureStorageConfig(RohmuModel):
     storage_type: Literal[RohmuStorageType.azure]
     account_name: str
     bucket_name: str
     account_key: Optional[str] = None
-    client_config: Optional[RohmuAzureServicePrincipalConfig] = None
+    sas_token: Optional[str] = None
     prefix: Optional[str] = None
     azure_cloud: Optional[str] = None
 


### PR DESCRIPTION
Add sas_token to credential schema as a replacement for Azure Service Principal credentials. The benefits of authenticating using a [SAS token](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview) are two-fold:

1. Simpler credential schema: `sas_token` string instead of `client_id`, `client_secret`, and `tenant_id` required for Service Principal authentication
2. Increased security (better access management): If a SAS token is compromised for any reason, the Shared Access Policy (SAP) it was created with can be deleted to immediately revoke access to the container. On the other hand, if Service Principal credentials are compromised, its credentials must be rotated and redistributed to any service that relied on the original credentials to continue performing backup operations.