### PR TITLE
clickhouse: use transaction when creating Replicated entities

### DIFF
--- a/astacus/coordinator/plugins/zookeeper.py
+++ b/astacus/coordinator/plugins/zookeeper.py
@@ -81,6 +81,22 @@ class ZooKeeperConnection:
         """
         raise NotImplementedError
 
+    async def try_create(self, path: str, value: bytes) -> bool:
+        """
+        Creates the node with the specified `path` and `value`.
+
+        Auto-creates all parent nodes if they don't exist.
+
+        Does nothing if the node did not already exist.
+
+        Returns `True` if the node was created
+        """
+        try:
+            await self.create(path, value)
+            return True
+        except NodeExistsError:
+            return False
+
     async def create(self, path: str, value: bytes) -> None:
         """
         Creates the node with the specified `path` and `value`.

--- a/tests/integration/coordinator/plugins/clickhouse/test_zookeeper.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_zookeeper.py
@@ -69,10 +69,25 @@ async def test_kazoo_zookeeper_client_get_children_of_missing_node_fails(zookeep
 
 
 @pytest.mark.asyncio
+async def test_kazoo_zookeeper_client_try_create(zookeeper_client: KazooZooKeeperClient) -> None:
+    async with zookeeper_client.connect() as connection:
+        assert await connection.try_create("/new/try_create", b"new_content") is True
+        assert await connection.get("/new/try_create") == b"new_content"
+
+
+@pytest.mark.asyncio
+async def test_kazoo_zookeeper_client_try_create_failure(zookeeper_client: KazooZooKeeperClient) -> None:
+    async with zookeeper_client.connect() as connection:
+        await connection.create("/new/try_create_failure", b"content")
+        assert await connection.try_create("/new/try_create_failure", b"new_content") is False
+        assert await connection.get("/new/try_create_failure") == b"content"
+
+
+@pytest.mark.asyncio
 async def test_kazoo_zookeeper_client_create(zookeeper_client: KazooZooKeeperClient) -> None:
     async with zookeeper_client.connect() as connection:
-        assert await connection.create("/new/node", b"content")
-        assert await connection.get("/new/node") == b"content"
+        await connection.create("/new/create", b"content")
+        assert await connection.get("/new/create") == b"content"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/coordinator/plugins/clickhouse/test_zookeeper.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_zookeeper.py
@@ -2,8 +2,15 @@
 Copyright (c) 2021 Aiven Ltd
 See LICENSE for details
 """
-from astacus.coordinator.plugins.zookeeper import KazooZooKeeperClient, NodeExistsError, NoNodeError
-from tests.integration.conftest import get_kazoo_host, Service
+from astacus.coordinator.plugins.zookeeper import (
+    KazooZooKeeperClient,
+    NodeExistsError,
+    NoNodeError,
+    RolledBackError,
+    RuntimeInconsistency,
+    TransactionError,
+)
+from tests.integration.conftest import create_zookeeper, get_kazoo_host, Ports, Service
 
 import dataclasses
 import kazoo.client
@@ -76,14 +83,40 @@ async def test_kazoo_zookeeper_client_create_existing_node_fails(zookeeper_clien
 
 
 @pytest.mark.asyncio
-async def test_kazoo_zookeeper_client_bounded_failure_time(
-    zookeeper_client: KazooZooKeeperClient, zookeeper: Service, znode: ZNode
-) -> None:
+async def test_kazoo_zookeeper_transaction(zookeeper_client: KazooZooKeeperClient) -> None:
     async with zookeeper_client.connect() as connection:
-        zookeeper.process.kill()
-        start_time = time.monotonic()
-        with pytest.raises(Exception):
-            await connection.get(znode.path)
-        elapsed_time = time.monotonic() - start_time
-        # We allow for a bit of margin
-        assert elapsed_time < 10.0
+        transaction = connection.transaction()
+        transaction.create("/transaction_1", b"content")
+        transaction.create("/transaction_2", b"content")
+        await transaction.commit()
+        assert await connection.get("/transaction_1") == b"content"
+        assert await connection.get("/transaction_2") == b"content"
+
+
+@pytest.mark.asyncio
+async def test_kazoo_zookeeper_failing_transaction(zookeeper_client: KazooZooKeeperClient) -> None:
+    async with zookeeper_client.connect() as connection:
+        await connection.create("/failing_transaction_2", b"old_content")
+        transaction = connection.transaction()
+        transaction.create("/failing_transaction_1", b"content")
+        transaction.create("/failing_transaction_2", b"content")
+        transaction.create("/failing_transaction_3", b"content")
+        with pytest.raises(TransactionError) as raised:
+            await transaction.commit()
+        assert isinstance(raised.value.results[0], RolledBackError)
+        assert isinstance(raised.value.results[1], NodeExistsError)
+        assert isinstance(raised.value.results[2], RuntimeInconsistency)
+
+
+@pytest.mark.asyncio
+async def test_kazoo_zookeeper_client_bounded_failure_time(ports: Ports) -> None:
+    async with create_zookeeper(ports) as zookeeper:
+        zookeeper_client = KazooZooKeeperClient(hosts=[get_kazoo_host(zookeeper)], timeout=1)
+        async with zookeeper_client.connect() as connection:
+            zookeeper.process.kill()
+            start_time = time.monotonic()
+            with pytest.raises(Exception):
+                await connection.exists("/bounded_failure_time")
+            elapsed_time = time.monotonic() - start_time
+            # We allow for a bit of margin
+            assert elapsed_time < 10.0

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -593,7 +593,7 @@ async def test_creating_all_access_entities_can_be_retried() -> None:
         await connection.create("/clickhouse/access/P/a_policy", str(uuid.UUID(int=1)).encode())
         await connection.create(f"/clickhouse/access/uuid/{str(uuid.UUID(int=1))}", b"ATTACH ROW POLICY ...")
         await connection.create("/clickhouse/access/Q/a_quota", str(uuid.UUID(int=2)).encode())
-        await connection.create(f"/clickhouse/access/uuid/{str(uuid.UUID(int=3))}", b"ATTACH ROLE ...")
+        await connection.create(f"/clickhouse/access/uuid/{str(uuid.UUID(int=2))}", b"ATTACH QUOTA ...")
     await step.run_step(Cluster(nodes=[]), context)
     await check_restored_entities(client)
 

--- a/tests/unit/coordinator/plugins/test_zookeeper.py
+++ b/tests/unit/coordinator/plugins/test_zookeeper.py
@@ -2,7 +2,15 @@
 Copyright (c) 2021 Aiven Ltd
 See LICENSE for details
 """
-from astacus.coordinator.plugins.zookeeper import ChangeWatch, FakeZooKeeperClient, NodeExistsError, NoNodeError
+from astacus.coordinator.plugins.zookeeper import (
+    ChangeWatch,
+    FakeZooKeeperClient,
+    NodeExistsError,
+    NoNodeError,
+    RolledBackError,
+    RuntimeInconsistency,
+    TransactionError,
+)
 
 import pytest
 
@@ -91,4 +99,57 @@ async def test_fake_zookeeper_client_get_children_watch() -> None:
         await connection.get_children("/group/of", watch=change_watch)
         async with client.connect() as connection_2:
             await connection_2.create("/group/of/key_2", b"content")
+    assert change_watch.has_changed
+
+
+@pytest.mark.asyncio
+async def test_fake_zookeeper_transaction():
+    client = FakeZooKeeperClient()
+    async with client.connect() as connection:
+        transaction = connection.transaction()
+        transaction.create("/key_1", b"content")
+        transaction.create("/key_2", b"content")
+        await transaction.commit()
+        assert await connection.get("/key_1") == b"content"
+        assert await connection.get("/key_2") == b"content"
+
+
+@pytest.mark.asyncio
+async def test_fake_zookeeper_transaction_is_atomic():
+    client = FakeZooKeeperClient()
+    async with client.connect() as connection:
+        await connection.create("/key_2", b"old content")
+        transaction = connection.transaction()
+        transaction.create("/key_1", b"content")
+        transaction.create("/key_2", b"content")
+        transaction.create("/key_3", b"content")
+        with pytest.raises(TransactionError) as raised:
+            await transaction.commit()
+        assert not await connection.exists("/key_1")
+        assert await connection.get("/key_2") == b"old content"
+        # We fudge the equality a bit to simplify comparing exceptions
+        expected_errors = [RolledBackError("/key_1"), NodeExistsError("/key_2"), RuntimeInconsistency("/key_3")]
+        assert repr(raised.value.results) == repr(expected_errors)
+
+
+@pytest.mark.asyncio
+async def test_fake_zookeeper_transaction_does_not_implicitly_create_parents():
+    client = FakeZooKeeperClient()
+    async with client.connect() as connection:
+        transaction = connection.transaction()
+        transaction.create("/path/to/key_1", b"content")
+        with pytest.raises(TransactionError):
+            await transaction.commit()
+
+
+@pytest.mark.asyncio
+async def test_fake_zookeeper_transaction_generates_trigger():
+    client = FakeZooKeeperClient()
+    change_watch = ChangeWatch()
+    async with client.connect() as connection:
+        await connection.create("/key_1", b"content")
+        await connection.get_children("/", watch=change_watch)
+        transaction = connection.transaction()
+        transaction.create("/key_2", b"content")
+        await transaction.commit()
     assert change_watch.has_changed


### PR DESCRIPTION
This avoids partial entities that can disturb normal ClickHouse operations
and partially overwriting existing entities.