### PR TITLE
rohmu: Replace pghoard.rohmu with rohmu library

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,8 +36,6 @@ these.
 
 - push this to PIP
 
-- separate rohmu from pghoard (right now, pghoard dependency is bit .. ugly ..)
-
 - use result-url instead of polling for somewhat faster results for CLI
 
 

--- a/astacus.spec
+++ b/astacus.spec
@@ -8,7 +8,7 @@ Source0:        astacus-rpm-src.tar
 BuildArch:      noarch
 
 # These are used when e.g. in podman, creating package from scratch
-# using pre-commit + pip; psycopg2 is indirect dependency of pghoard
+# using pre-commit + pip
 BuildRequires:  gcc
 BuildRequires:  g++
 BuildRequires:  git
@@ -16,16 +16,15 @@ BuildRequires:  protobuf-compiler
 BuildRequires:  python3-chardet
 BuildRequires:  python3-devel
 BuildRequires:  python3-pip
-BuildRequires:  python3-psycopg2
 BuildRequires:  python3-wheel
 BuildRequires:  which
 
 # These are used when actually running the package
-Requires:       pghoard
 Requires:       python3-fastapi
 Requires:       python3-httpx
 Requires:       python3-protobuf
 Requires:       python3-pyyaml
+Requires:       python3-rohmu
 Requires:       python3-sentry-sdk
 Requires:       python3-tabulate
 Requires:       python3-typing-extensions

--- a/astacus/common/rohmustorage.py
+++ b/astacus/common/rohmustorage.py
@@ -11,10 +11,9 @@ from .storage import MultiStorage, Storage, StorageUploadResult
 from .utils import AstacusModel
 from astacus.common import exceptions
 from enum import Enum
-from pghoard import rohmu  # type: ignore
-from pghoard.rohmu import rohmufile  # type: ignore
-from pghoard.rohmu import errors
 from pydantic import DirectoryPath, Field
+from rohmu import rohmufile  # type: ignore
+from rohmu import errors
 from typing import Dict, Optional, Union
 from typing_extensions import Literal
 
@@ -22,6 +21,7 @@ import io
 import json
 import logging
 import os
+import rohmu  # type: ignore
 import tempfile
 
 logger = logging.getLogger(__name__)
@@ -171,7 +171,7 @@ def rohmu_error_wrapper(fun):
 
 
 class RohmuStorage(Storage):
-    """Implementation of the storage API, on top of pghoard.rohmu."""
+    """Implementation of the storage API, on top of rohmu."""
 
     def __init__(self, config: RohmuConfig, *, storage=None):
         assert config

--- a/doc/design/implementation.md
+++ b/doc/design/implementation.md
@@ -3,12 +3,12 @@
 ## Platform choices
 
 - Target latest reasonable Python (3.8 or later)
-    - Go was also on the table, but pghoard.rohmu is compelling reason to
+    - Go was also on the table, but rohmu is compelling reason to
       use Python
 - Use [pytest][pytest] for unit tests
-- Use pghoard.rohmu from [pghoard][pghoard] for object storage interface
+- Use [rohmu][rohmu] for object storage interface
 - Use [fastapi][fastapi] for REST API implementation(s)
 
-[pghoard]: https://pypi.org/project/pghoard/
+[rohmu]: https://pypi.org/project/rohmu/
 [fastapi]: https://fastapi.tiangolo.com
 [pytest]: https://docs.pytest.org/en/latest/

--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -2,6 +2,7 @@
 pre-commit>=2.2.0
 
 # pre-commit tasks in Makefile need these
+anyio==2.0.2
 mypy==0.910
 pylint==2.9.6
 pytest-asyncio==0.14.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,15 +13,11 @@ install_requires =
   fastapi==0.66.0
   httpx==0.16.1
   protobuf==3.14.0
+  rohmu==1.0.1
   sentry-sdk==0.13.5
   tabulate==0.8.9
   typing-extensions==3.7.4.3
   uvicorn==0.13.3
-  pghoard
-# pghoard optional dependencies
-#  azure-mgmt-storage
-#  botocore
-# pghoard google
   google-api-python-client==1.6.7
   oauth2client==4.1.3
 

--- a/tests/unit/common/test_storage.py
+++ b/tests/unit/common/test_storage.py
@@ -14,11 +14,10 @@ from astacus.common.rohmustorage import RohmuConfig, RohmuStorage
 from astacus.common.storage import FileStorage, JsonStorage
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
-from pghoard.rohmu.object_storage import google
+from rohmu.object_storage import google
 from tests.utils import create_rohmu_config
 from unittest.mock import patch
 
-import pkg_resources
 import pytest
 
 TEST_HEXDIGEST = "deadbeef"
@@ -110,11 +109,7 @@ def test_caching_storage(tmpdir, mocker):
     assert not mocklist.called
 
 
-@pytest.mark.skipif(
-    pkg_resources.get_distribution("pghoard").parsed_version <= pkg_resources.parse_version("2.1.0"),
-    reason="requires pghoard > 2.1.0",
-)
-@patch("pghoard.rohmu.object_storage.google.get_credentials")
+@patch("rohmu.object_storage.google.get_credentials")
 @patch.object(google.GoogleTransfer, "_init_google_client")
 def test_proxy_storage(mock_google_client, mock_get_credentials):
     rs = RohmuStorage(


### PR DESCRIPTION
Drop the pghoard dependency, depend only on the library itself.