### PR TITLE
coordinator: fix asyncio in sync dependency injectors

### DIFF
--- a/astacus/coordinator/api.py
+++ b/astacus/coordinator/api.py
@@ -63,13 +63,13 @@ def unlock(*, locker: str, c: Coordinator = Depends(), op: LockOps = Depends()):
 
 
 @router.post("/backup")
-async def backup(*, c: Coordinator = Depends(), op: BackupOp = Depends()):
+async def backup(*, c: Coordinator = Depends(), op: BackupOp = Depends(BackupOp.create)):
     runner = await op.acquire_cluster_lock()
     return c.start_op(op_name=OpName.backup, op=op, fun=runner)
 
 
 @router.post("/restore")
-async def restore(*, c: Coordinator = Depends(), op: RestoreOp = Depends()):
+async def restore(*, c: Coordinator = Depends(), op: RestoreOp = Depends(RestoreOp.create)):
     runner = await op.acquire_cluster_lock()
     return c.start_op(op_name=OpName.restore, op=op, fun=runner)
 

--- a/astacus/coordinator/coordinator.py
+++ b/astacus/coordinator/coordinator.py
@@ -318,14 +318,22 @@ class SteppedCoordinatorOp(LockedCoordinatorOp):
 
 
 class BackupOp(SteppedCoordinatorOp):
-    def __init__(self, *, c: Coordinator = Depends()):
+    @staticmethod
+    async def create(*, c: Coordinator = Depends()) -> "BackupOp":
+        return BackupOp(c=c)
+
+    def __init__(self, *, c: Coordinator) -> None:
         context = c.get_operation_context()
         steps = c.get_plugin().get_backup_steps(context=context)
         super().__init__(c=c, attempts=c.config.backup_attempts, steps=steps)
 
 
 class RestoreOp(SteppedCoordinatorOp):
-    def __init__(self, *, c: Coordinator = Depends(), req: ipc.RestoreRequest = ipc.RestoreRequest()):
+    @staticmethod
+    async def create(*, c: Coordinator = Depends(), req: ipc.RestoreRequest = ipc.RestoreRequest()) -> "RestoreOp":
+        return RestoreOp(c=c, req=req)
+
+    def __init__(self, *, c: Coordinator, req: ipc.RestoreRequest) -> None:
         context = c.get_operation_context(requested_storage=req.storage)
         steps = c.get_plugin().get_restore_steps(context=context, req=req)
         if req.stop_after_step is not None:


### PR DESCRIPTION
fastapi dependency injector runs all non-async injection functions in a separate thread, where the asyncio event loop is not available.
This breaks injection functions where we create async objects without using async/await.
A class constructor is a non-async function, we need to wrap it in an async function to avoid the fastapi thread:

    Traceback (most recent call last):
      File ".../uvicorn/protocols/http/h11_impl.py", line 384, in run_asgi
        result = await app(self.scope, self.receive, self.send)
      File ".../uvicorn/middleware/proxy_headers.py", line 45, in __call__
        return await self.app(scope, receive, send)
      File ".../fastapi/applications.py", line 146, in __call__
        await super().__call__(scope, receive, send)
      File ".../starlette/applications.py", line 102, in __call__
        await self.middleware_stack(scope, receive, send)
      File ".../starlette/middleware/errors.py", line 181, in __call__
        raise exc from None
      File ".../starlette/middleware/errors.py", line 159, in __call__
        await self.app(scope, receive, _send)
      File ".../starlette/exceptions.py", line 82, in __call__
        raise exc from None
      File ".../starlette/exceptions.py", line 71, in __call__
        await self.app(scope, receive, sender)
      File ".../starlette/routing.py", line 550, in __call__
        await route.handle(scope, receive, send)
      File ".../starlette/routing.py", line 227, in handle
        await self.app(scope, receive, send)
      File ".../starlette/routing.py", line 41, in app
        response = await func(request)
      File ".../fastapi/routing.py", line 186, in app
        solved_result = await solve_dependencies(
      File ".../fastapi/dependencies/utils.py", line 511, in solve_dependencies
        solved = await run_in_threadpool(call, **sub_values)
      File ".../starlette/concurrency.py", line 34, in run_in_threadpool
        return await loop.run_in_executor(None, func, *args)
      File ".../concurrent/futures/thread.py", line 58, in run
        result = self.fn(*self.args, **self.kwargs)
      File ".../astacus/coordinator/coordinator.py", line 323, in __init__
        steps = c.get_plugin().get_backup_steps(context=context)
      File ".../astacus/coordinator/plugins/clickhouse/plugin.py", line 58, in get_backup_steps
        zookeeper_client = get_zookeeper_client(self.zookeeper)
      File ".../astacus/coordinator/plugins/clickhouse/config.py", line 33, in get_zookeeper_client
        return KazooZooKeeperClient(hosts=[build_netloc(node.host, node.port) for node in configuration.nodes])
      File ".../astacus/coordinator/plugins/zookeeper.py", line 170, in __init__
        self.lock = asyncio.Lock()
      File "/usr/lib64/python3.9/asyncio/locks.py", line 81, in __init__
        self._loop = events.get_event_loop()
      File "/usr/lib64/python3.9/asyncio/events.py", line 642, in get_event_loop
        raise RuntimeError('There is no current event loop in thread %r.'