### PR TITLE
Miscellaneous fixes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,9 +14,6 @@ name: "CodeQL"
 on:
   push:
     branches: [ master ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master ]
   schedule:
     - cron: '42 20 * * 6'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,23 +1,24 @@
 name: Lint
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.9
 
       - name: Install dependencies
         run: make build-dep-ubuntu
 
+      - name: Set up Python 3.10 with caching
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
       - name: Install requirements
-        run: python3 -m pip install -r requirements.txt
+        run: pip install -r requirements.txt
 
       - name: Run all pre-commit hooks
         run: make lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,10 @@
 name: Test Suite
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 4
       matrix:
@@ -12,16 +12,17 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-
     - name: Install dependencies
       run: make build-dep-ubuntu test-dep-ubuntu
 
+    - name: Set up Python ${{ matrix.python-version }} with caching
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
     - name: Install requirements
-      run: python3 -m pip install -r requirements.txt
+      run: pip install -r requirements.txt
 
     - name: Execute unit-tests
       run: make unittest

--- a/.pylintrc
+++ b/.pylintrc
@@ -2,11 +2,11 @@
 string-quote=double-avoid-escape
 triple-quote=double
 docstring-quote=double
-jobs=4
 
 [MESSAGES CONTROL]
 disable=
     bad-continuation,
+    duplicate-code,                # the checker in 2.9.6 fails with parallelism
     invalid-name,                  # fastapi conventions break this
     missing-docstring,
     no-member,                     # broken with pydantic + inheritance
@@ -27,8 +27,3 @@ score=no
 [TYPECHECK]
 ignored-classes=responses
 extension-pkg-whitelist=pydantic
-
-[SIMILARITIES]
-# Ignore import statements when computing similarities
-ignore-imports=yes
-min-similarity-lines=6

--- a/TODO.md
+++ b/TODO.md
@@ -12,12 +12,6 @@ these.
     - the design
     - user-visible UI etc
 
-- improve operation reporting; probably astacus.common.progress.Progress
-  information should be also forwarded to coordinator results, and
-  subsequently to REST/CLI. Currently coordinator REST API / CLI reports
-  just binary outcome (success/not) which while technically sufficient in
-  short term, isn't optimal
-
 - measure, improve test code coverage
 
 - more metrics endpoints - think on what is really needed

--- a/astacus/node/download.py
+++ b/astacus/node/download.py
@@ -43,7 +43,7 @@ class Downloader(ThreadLocalStorage):
         relative_path = snapshotfile.relative_path
         download_path = self.dst / relative_path
         download_path.parent.mkdir(parents=True, exist_ok=True)
-        with download_path.open("wb") as f:
+        with utils.open_path_with_atomic_rename(download_path) as f:
             if snapshotfile.hexdigest:
                 self.local_storage.download_hexdigest_to_file(snapshotfile.hexdigest, f)
             else:

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,3 +15,6 @@ ignore_missing_imports = True
 
 [mypy-kazoo.*]
 ignore_missing_imports = True
+
+[mypy-h11.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,7 @@ install_requires =
   tabulate==0.8.9
   typing-extensions==3.7.4.3
   uvicorn==0.13.3
-  google-api-python-client==1.6.7
-  oauth2client==4.1.3
 
-# Cassandra support (this could be made somehow optional but oh well)
-  cassandra-driver==3.20.0
   # Clickhouse support
   kazoo
   graphlib-backport;python_version<'3.9'

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ def _run():
     setuptools.setup(
         version=version_for_setup_py,
         packages=setuptools.find_packages(exclude=["test"]),
-        extras_require={},
+        extras_require={
+            "cassandra": ["cassandra-driver==3.20.2"],
+        },
         dependency_links=[],
         package_data={},
         entry_points={

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -9,6 +9,7 @@ Test astacus.common.utils
 from astacus.common import utils
 from astacus.common.utils import AsyncSleeper, build_netloc
 from datetime import timedelta
+from pathlib import Path
 
 import asyncio
 import logging
@@ -147,3 +148,29 @@ def test_sizelimitedfile():
         assert not lf.read()
         assert lf.seek(3, 0) == 3
         assert lf.read() == b"bar"
+
+
+def test_open_path_with_atomic_rename(tmpdir):
+    # default is bytes
+    f1_path = f"{tmpdir}/f1"
+    with utils.open_path_with_atomic_rename(f1_path) as f1:
+        f1.write(b"test1")
+    assert Path(f1_path).read_text() == "test1"
+
+    # text mode requires passing mode flag but should work
+    f2_path = f"{tmpdir}/f2"
+    with utils.open_path_with_atomic_rename(f2_path, mode="w") as f2:
+        f2.write("test2")
+    assert Path(f2_path).read_text() == "test2"
+
+    # rewriting should be fine too
+    with utils.open_path_with_atomic_rename(f2_path, mode="w") as f2:
+        f2.write("test2-new")
+    assert Path(f2_path).read_text() == "test2-new"
+
+    # erroneous cases should not produce file at all
+    f3_path = f"{tmpdir}/f3"
+    with pytest.raises(AssertionError):
+        with utils.open_path_with_atomic_rename(f3_path):
+            assert False
+    assert not Path(f3_path).exists()


### PR DESCRIPTION
- .pylintrc: Some tuning
- GHA tuning
- TODO: Reporting was fixed earlier
- common: Add open_path_with_atomic_rename to utils and use it in node download
- mypy.ini: Added h11 as ignored
- setup: Some requirements tuning

See commits for more details

made cassandra driver optional -> PRs should be much faster until we get cassandra really in