### PR TITLE
Cassandra support - 2022 edition

### DIFF
--- a/.github/workflows/tests-all.yml
+++ b/.github/workflows/tests-all.yml
@@ -1,6 +1,10 @@
 name: Test Suite (Maximal)
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   unit-test:
@@ -29,3 +33,9 @@ jobs:
 
     - name: Execute unit-tests
       run: make unittest
+
+    - id: upload-codecov
+      # Third-party action pinned to v2.1.0
+      uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b
+      with:
+        verbose: true

--- a/.github/workflows/tests-all.yml
+++ b/.github/workflows/tests-all.yml
@@ -1,8 +1,6 @@
-name: Test Suite (Minimal)
+name: Test Suite (Maximal)
 
 on: pull_request
-
-# Note: This test runs only on one Python version the minimal pip install
 
 jobs:
   unit-test:
@@ -10,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.9', '3.10']
     steps:
     - uses: actions/checkout@v1
 
@@ -24,7 +22,10 @@ jobs:
         cache: 'pip'
 
     - name: Install requirements
-      run: pip install -r requirements.txt
+      run: pip install -e '.[cassandra]'
+
+    - name: Install testing requirements (not included by default in normal install)
+      run: pip install -r requirements.testing.txt
 
     - name: Execute unit-tests
       run: make unittest

--- a/.pylintrc
+++ b/.pylintrc
@@ -26,4 +26,5 @@ score=no
 
 [TYPECHECK]
 ignored-classes=responses
-extension-pkg-whitelist=pydantic
+ignored-modules=cassandra
+extension-pkg-whitelist=pydantic,cassandra.cluster,cassandra.metadata,cassandra.query

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -9,7 +9,8 @@ ADD Makefile astacus.spec /build/
 RUN cd /build && make build-dep-fedora
 
 ADD README.md setup.cfg setup.py requirements*.txt /build/
-RUN cd /build && python3 -m pip install -r requirements.txt
+RUN cd /build && pip3 install -e '.[cassandra]'
+RUN cd /build && pip3 install -r requirements.testing.txt
 
 # This step depends on pre-commit installed from requirements.txt
 ADD .pre-commit-config.yaml /build/

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -10,7 +10,8 @@ ADD Makefile /build/
 RUN cd /build && make build-dep-ubuntu
 
 ADD README.md setup.cfg setup.py requirements*.txt /build/
-RUN cd /build && python3 -m pip install -r requirements.txt
+RUN cd /build && pip3 install -e '.[cassandra]'
+RUN cd /build && pip3 install -r requirements.testing.txt
 
 # This step depends on pre-commit installed from requirements.txt
 ADD .pre-commit-config.yaml /build/

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,11 @@ copyright:
 .PHONY: unittest
 unittest: $(GENERATED)
 	rm -rf htmlcov
-	python3 -m pytest --cov=./ --cov-report=html -s -vvv -x tests/
+	python3 -m pytest --cov=./ \
+		--cov-report=html \
+		--cov-report term-missing \
+		--cov-report xml:coverage.xml \
+		-s -vvv -x tests/
 
 .PHONY: test
 test: lint copyright unittest

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ GENERATED = astacus/version.py $(GENERATED_PROTOBUFS)
 PYTHON = python3
 DNF_INSTALL = sudo dnf install -y
 
+ZOOKEEPER_VERSION = 3.5.10
+ZOOKEEPER_HASH = 87e555869211cc3dc5f3cdfe7c22124b62605dac50a14e6c84e7e66b583c4eb3
+
 default: $(GENERATED)
 
 clean:
@@ -31,10 +34,10 @@ build-dep-ubuntu:
 
 .PHONY: test-dep-ubuntu
 test-dep-ubuntu:
-	wget --no-verbose https://dlcdn.apache.org/zookeeper/zookeeper-3.5.9/apache-zookeeper-3.5.9-bin.tar.gz
-	echo "7ad00caf8374edc984b9204cd585ad151c8ed19969045d0c23666b18a8102548  apache-zookeeper-3.5.9-bin.tar.gz" | sha256sum -c -
-	tar vxf apache-zookeeper-3.5.9-bin.tar.gz --wildcards apache-zookeeper-3.5.9-bin/lib/*.jar
-	sudo cp -r apache-zookeeper-3.5.9-bin/lib /usr/share/zookeeper
+	wget --no-verbose https://dlcdn.apache.org/zookeeper/zookeeper-$(ZOOKEEPER_VERSION)/apache-zookeeper-$(ZOOKEEPER_VERSION)-bin.tar.gz
+	echo "$(ZOOKEEPER_HASH)  apache-zookeeper-$(ZOOKEEPER_VERSION)-bin.tar.gz" | sha256sum -c -
+	tar vxf apache-zookeeper-$(ZOOKEEPER_VERSION)-bin.tar.gz --wildcards apache-zookeeper-$(ZOOKEEPER_VERSION)-bin/lib/*.jar
+	sudo cp -r apache-zookeeper-$(ZOOKEEPER_VERSION)-bin/lib /usr/share/zookeeper
 
 .PHONY: pylint
 pylint: $(GENERATED)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ shared code
 Please see Dockerfile.fedora and Dockerfile.ubuntu for concrete up-to-date
 examples, but here are the current ones:
 
+## Optional features
+
+- cassandra can be added with 'cassandra' optional:
+```
+sudo pip3 install -e '.[cassandra]'
+```
+
+
+
 ## Fedora 34
 
 (as root or user with sudo access; for root, skip sudo prefix)

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,5 @@
 # List of things that need to be implemented #
 
-Note: This is more granular and detailed version what should be done; there
-is also (Aiven-internal) backlog of Astacus tickets that track subset of
-these.
-
 
 ## Short-term
 
@@ -17,11 +13,23 @@ these.
 - more metrics endpoints - think on what is really needed
     - perhaps backup/snapshot/restore sizes and file counts? copy from *hoard?
 
-- plugin
-    - (partial?) cassandra plugin; mostly to validate plugin arch is broad enough
-
 
 ## Eventually
+
+- Cassandra partial restore support; notably, we should be able to recover
+  single nodes (perhaps in this case, if version matches, restore both
+  system keyspace AND user keyspaces, and avoid the create steps in full
+  restore)
+
+- Cassandra specific table restore support; we should then pick more
+  carefully where exactly we are restoring things:
+  - get table ids for freshly created tables (during restore when Cassandra
+    is up from system_schema.tables)
+  - pass the keyspace+table+table id tuples to the actual restore Cassandra
+    step
+    - clear the directory
+    - move files to it
+
 
 - package (or have someone do it?) this for distros
 
@@ -31,6 +39,10 @@ these.
 - push this to PIP
 
 - use result-url instead of polling for somewhat faster results for CLI
+
+- we should have some sort of packfile format for small files - right now,
+  the embed-in-manifest kind of works, but is not pretty, and doesn't work
+  for still trivial sized files
 
 
 ## Maybe not - known design choice for now

--- a/astacus/common/cassandra/client.py
+++ b/astacus/common/cassandra/client.py
@@ -1,0 +1,101 @@
+"""
+Copyright (c) 2021 Aiven Ltd
+See LICENSE for details
+
+This client code is originally from Cashew
+
+"""
+
+from .config import CassandraClientConfiguration
+from astacus.common.exceptions import TransientException
+from cassandra import ConsistencyLevel, metadata as cm
+from cassandra.auth import PlainTextAuthProvider
+from cassandra.cluster import Cluster, NoHostAvailable, Session
+from cassandra.policies import WhiteListRoundRobinPolicy
+from cassandra.query import SimpleStatement
+from contextlib import contextmanager
+from ssl import CERT_REQUIRED
+from starlette.concurrency import run_in_threadpool
+from typing import Any, Callable, Generator
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class NoHostAvailableException(TransientException):
+    pass
+
+
+class CassandraSession:
+    def __init__(self, cluster: Cluster, session: Session):
+        self._cluster = cluster
+        self._session = session
+
+    @property
+    def cluster_metadata(self) -> cm.Metadata:
+        return self._cluster.metadata
+
+    def cluster_refresh_schema_metadata(self, *, max_schema_agreement_wait: float) -> None:
+        self._cluster.refresh_schema_metadata(max_schema_agreement_wait=max_schema_agreement_wait)
+
+    def execute(self, stmt: str) -> Any:
+        return self._session.execute(SimpleStatement(stmt, consistency_level=ConsistencyLevel.ONE))
+
+    def execute_on_all(self, statement: str) -> None:
+        # backup schema for at least a table may consist of multiple statements
+        for stmt in statement.split(";\n\n"):
+            # TBD: Is ;\n\n valid character in something included in schema? UDF? Hopefully not.
+            self._session.execute(SimpleStatement(stmt, consistency_level=ConsistencyLevel.ALL))
+
+
+class CassandraClient:
+    def __init__(self, config: CassandraClientConfiguration):
+        self._config = config
+
+    @contextmanager
+    def connect(self) -> Generator[CassandraSession, None, None]:
+        config = self._config
+        hostnames = config.get_hostnames()
+
+        # NB: a session is needed even though it's not directly referenced, otherwise cassandra driver wont establish a
+        # control connection and refreshing metadata fails
+        if config.ca_cert_path:
+            ssl_options = {
+                "ca_certs": config.ca_cert_path,
+                "cert_reqs": CERT_REQUIRED,
+            }
+        else:
+            # TBD what the default should be otherwise
+            ssl_options = {}
+
+        try:
+            with Cluster(
+                connect_timeout=15,
+                contact_points=hostnames,
+                control_connection_timeout=15,
+                port=config.get_port(),
+                ssl_options=ssl_options,
+                auth_provider=PlainTextAuthProvider(config.username, config.password),
+                load_balancing_policy=WhiteListRoundRobinPolicy(hostnames),
+            ) as cluster, cluster.connect() as session:
+                yield CassandraSession(cluster, session)
+        except NoHostAvailable as ex:
+            if isinstance(ex.errors, dict):
+                error_values = list(ex.errors.values())
+            elif isinstance(ex.errors, list):
+                error_values = ex.errors
+            else:
+                raise NotImplementedError(ex.errors) from ex
+
+            error = error_values[0]
+
+            logger.exception("Unexpected exception while connecting to local cassandra: %r", error)
+            raise NoHostAvailableException from ex
+
+    async def run_sync(self, fun: Callable, *args: Any, **kwargs: Any) -> Any:
+        def run() -> Any:
+            with self.connect() as cas:
+                return fun(cas, *args, **kwargs)
+
+        return await run_in_threadpool(run)

--- a/astacus/common/cassandra/config.py
+++ b/astacus/common/cassandra/config.py
@@ -1,0 +1,66 @@
+"""Copyright (c) 2021 Aiven Ltd
+See LICENSE for details
+
+Client configuration data model
+
+Note that resides in its own file mostly because it is imported in few
+places in Astacus; the other modules in the directory have
+dependencies on the actual cassandra driver, but this one does not.
+
+
+NOTE: While caching e.g. self.get_config result would be tempting (and
+even moreso get_port and get_hostnames), sadly pydantic and functools
+do not live together too well: see
+https://github.com/samuelcolvin/pydantic/issues/3376
+
+
+"""
+
+from astacus.common.utils import AstacusModel
+from pathlib import Path
+from pydantic import root_validator
+from typing import List, Optional
+
+import yaml
+
+SNAPSHOT_NAME = "astacus-backup"
+
+
+class CassandraClientConfiguration(AstacusModel):
+    config_path: Optional[Path]
+
+    # WhiteListRoundRobinPolicy contact points
+    hostnames: Optional[List[str]]
+
+    port: Optional[int]
+
+    # PlainTextAuthProvider
+    username: str
+    password: str
+
+    # If set, configure ssl access configuration which requires the ca cert
+    ca_cert_path: Optional[str]
+
+    @classmethod
+    @root_validator
+    def config_or_hostname_port_provided(cls, values: dict) -> dict:
+        assert "config_path" in values or "port" in values, "Either config_path, or port must be provided"
+        return values
+
+    def get_port(self) -> int:
+        if self.port:
+            return self.port
+        return int(self.get_config()["native_transport_port"])
+
+    def get_hostnames(self) -> List[str]:
+        if self.hostnames:
+            return self.hostnames
+        return ["127.0.0.1"]
+
+    def get_listen_address(self) -> str:
+        return self.get_config()["listen_address"]
+
+    def get_config(self) -> dict:
+        assert self.config_path
+        with self.config_path.open() as f:
+            return yaml.safe_load(f)

--- a/astacus/common/cassandra/schema.py
+++ b/astacus/common/cassandra/schema.py
@@ -1,0 +1,356 @@
+"""
+Copyright (c) 2021 Aiven Ltd
+See LICENSE for details
+
+Schema-related parts are based on basebackup_schema.py of Cashew
+
+"""
+
+from .client import CassandraSession
+from .utils import is_system_keyspace
+from astacus.common.utils import AstacusModel
+from cassandra import metadata as cm
+from typing import Any, Iterator, List, Set
+
+import hashlib
+import itertools
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# https://cassandra.apache.org/doc/trunk/cassandra/cql/definitions.html
+UNQUOTED_IDENTIFIER_RE = "[a-zA-Z][a-zA-Z0-9_]*"
+QUOTED_IDENTIFIER_RE = '"(?:[^"]|"")+"'
+IDENTIFIER_RE = f"(?:{UNQUOTED_IDENTIFIER_RE}|{QUOTED_IDENTIFIER_RE})"
+
+
+class CassandraNamed(AstacusModel):
+    """~abstract baseclass for something that has a name, and has cql for creating itself."""
+
+    name: str
+    cql_create_self: str
+
+    def __lt__(self, o: "CassandraNamed") -> bool:
+        # Almost all object names are unique in Cassandra, with
+        # exception of functions (see below)
+        return self.name < o.name
+
+    @classmethod
+    def from_cassandra_metadata(cls, metadata: Any) -> Any:
+        return cls(name=metadata.name, cql_create_self=metadata.as_cql_query())
+
+    def restore_if_needed(self, cas: CassandraSession, existing_map: dict) -> None:
+        if self.name in existing_map:
+            logger.debug("%r with name %r already exists", self.__class__.__name__, self.name)
+            return
+        logger.info("Creating %r %r", self.__class__.__name__, self.name)
+        cas.execute_on_all(self.cql_create_self)
+
+
+def _iterate_identifiers_in_cql_type_definition(definition: str) -> Iterator[str]:
+    # parsing might be more proper, but this is sufficient
+    for identifier in re.findall(IDENTIFIER_RE, definition):
+        if identifier.startswith('"'):
+            # quoted identifier
+            unquoted = identifier[1:-1].replace('""', '"')
+            yield unquoted
+        else:
+            # this lower is spurious, but here for
+            # understandability - Cassandra normalizes
+            # unquoted identifiers by default
+            normalized = identifier.lower()
+
+            # these are picked from https://cassandra.apache.org/doc/trunk/cassandra/cql/types.html
+            if normalized not in {"map", "set", "list", "frozen", "tuple"}:
+                yield normalized
+
+
+class CassandraUserType(CassandraNamed):
+    field_types: List[str]
+
+    @classmethod
+    def from_cassandra_metadata(cls, metadata: cm.UserType) -> "CassandraUserType":
+        return cls(name=metadata.name, cql_create_self=metadata.as_cql_query(), field_types=metadata.field_types)
+
+    def referred_normalized_identifiers(self) -> Set[str]:
+        def iterate_identifiers() -> Iterator[str]:
+            for field_type in self.field_types:
+                yield from _iterate_identifiers_in_cql_type_definition(field_type)
+
+        return set(iterate_identifiers())
+
+    def restore_in_keyspace(self, cas: CassandraSession, keyspace_metadata: cm.KeyspaceMetadata) -> None:
+        self.restore_if_needed(cas, keyspace_metadata.user_types)
+
+
+class CassandraFunction(CassandraNamed):
+    argument_types: List[str]
+
+    def __lt__(self, o: CassandraNamed) -> bool:
+        assert isinstance(o, CassandraFunction)
+        # Cassandra can have multiple functions with same name, as
+        # long as argument types differ. So use them for sorting too.
+        if self.name < o.name:
+            return True
+        if self.argument_types < o.argument_types:
+            return True
+        return False
+
+    @classmethod
+    def get_create_statement(cls, metadata: cm.Function) -> str:
+        """
+        Based on Function.as_cql_query, but doesn't strip `frozen` from arguments as they need to be specified on restoration
+        With default cassandra-driver the function fails to create with an error message like "Non-frozen UDTs are not
+        allowed inside collections: ..."
+        """
+        sep = " "
+        keyspace = cm.protect_name(metadata.keyspace)
+        name = cm.protect_name(metadata.name)
+        arg_list = ", ".join(
+            "{} {}".format(cm.protect_name(arg_name), arg_type)
+            for arg_name, arg_type in zip(metadata.argument_names, metadata.argument_types)
+        )
+        typ = metadata.return_type
+        lang = metadata.language
+        body = metadata.body
+        on_null = "CALLED" if metadata.called_on_null_input else "RETURNS NULL"
+
+        return (
+            f"CREATE FUNCTION {keyspace}.{name}({arg_list}){sep}"
+            f"{on_null} ON NULL INPUT{sep}"
+            f"RETURNS {typ}{sep}"
+            f"LANGUAGE {lang}{sep}"
+            f"AS $${body}$$"
+        )
+
+    @classmethod
+    def from_cassandra_metadata(cls, metadata: cm.Function) -> "CassandraFunction":
+        return cls(
+            name=metadata.name,
+            cql_create_self=cls.get_create_statement(metadata=metadata),
+            argument_types=metadata.argument_types,
+        )
+
+    def get_metadata_dict(self, keyspace_metadata: cm.KeyspaceMetadata) -> dict:
+        return keyspace_metadata.functions
+
+    def restore_in_keyspace(self, cas: CassandraSession, keyspace_metadata: cm.KeyspaceMetadata) -> None:
+        pretty_name = "{}.{}({})".format(
+            keyspace_metadata.name,
+            self.name,
+            ", ".join(self.argument_types),
+        )
+        for funcagg_metadata in self.get_metadata_dict(keyspace_metadata).values():
+            if funcagg_metadata.name == self.name and funcagg_metadata.argument_types == self.argument_types:
+                logger.info("%s %s already exists, not creating it", self.__class__.__name__, pretty_name)
+                break
+        else:
+            logger.info("Creating %s %s", self.__class__.__name__, pretty_name)
+            cas.execute_on_all(self.cql_create_self)
+
+
+class CassandraAggregate(CassandraFunction):
+    @classmethod
+    def get_create_statement(cls, metadata: cm.Aggregate) -> str:
+        sep = " "
+        keyspace = cm.protect_name(metadata.keyspace)
+        name = cm.protect_name(metadata.name)
+        type_list = ", ".join(metadata.argument_types)
+        state_func = cm.protect_name(metadata.state_func)
+        state_type = metadata.state_type
+
+        ret = f"CREATE AGGREGATE {keyspace}.{name}({type_list}){sep}" f"SFUNC {state_func}{sep}" f"STYPE {state_type}"
+
+        if metadata.final_func:
+            ret += "{}FINALFUNC {}".format(sep, cm.protect_name(metadata.final_func))
+        if metadata.initial_condition:
+            ret += f"{sep}INITCOND {metadata.initial_condition}"
+
+        return ret
+
+    @classmethod
+    def from_cassandra_metadata(cls, metadata: cm.Aggregate) -> "CassandraAggregate":
+        return cls(
+            name=metadata.name,
+            cql_create_self=cls.get_create_statement(metadata=metadata),
+            argument_types=metadata.argument_types,
+        )
+
+    def get_metadata_dict(self, keyspace_metadata: cm.KeyspaceMetadata) -> dict:
+        return keyspace_metadata.aggregates
+
+
+class CassandraIndex(CassandraNamed):
+    # from_cassandra_metadata covered by superclass
+    pass
+
+
+class CassandraMaterializedView(CassandraNamed):
+    # from_cassandra_metadata covered by superclass
+    pass
+
+
+class CassandraTrigger(CassandraNamed):
+    # from_cassandra_metadata covered by superclass
+    pass
+
+
+class CassandraTable(CassandraNamed):
+    indexes: List[CassandraIndex]
+    materialized_views: List[CassandraMaterializedView]
+    triggers: List[CassandraTrigger]
+
+    @classmethod
+    def from_cassandra_metadata(cls, metadata: cm.TableMetadata) -> "CassandraTable":
+        return cls(
+            # CassandraNamed
+            name=metadata.name,
+            cql_create_self=metadata.as_cql_query(),
+            # CassandraTable
+            indexes=sorted(CassandraIndex.from_cassandra_metadata(metadata) for metadata in metadata.indexes.values()),
+            materialized_views=sorted(
+                CassandraMaterializedView.from_cassandra_metadata(metadata) for metadata in metadata.views.values()
+            ),
+            triggers=sorted(CassandraTrigger.from_cassandra_metadata(metadata) for metadata in metadata.triggers.values()),
+        )
+
+    def restore_post_data_in_keyspace(self, cas: CassandraSession, keyspace_metadata: cm.KeyspaceMetadata) -> None:
+        table_metadata = keyspace_metadata.tables[self.name]
+        for resource_map, resource_list in [
+            [table_metadata.indexes, self.indexes],
+            [table_metadata.triggers, self.triggers],
+            [table_metadata.views, self.materialized_views],
+        ]:
+            for resource in resource_list:
+                resource.restore_if_needed(cas, resource_map)
+
+
+class CassandraKeyspace(CassandraNamed):
+    # CQL to create everything
+    cql_create_all: str
+
+    aggregates: List[CassandraAggregate]
+    functions: List[CassandraFunction]
+    tables: List[CassandraTable]
+    user_types: List[CassandraUserType]
+
+    @classmethod
+    def from_cassandra_metadata(cls, metadata: cm.KeyspaceMetadata) -> "CassandraKeyspace":
+        return cls(
+            # CassandraNamed
+            name=metadata.name,
+            cql_create_self=metadata.as_cql_query(),
+            # CassandraKeyspace
+            cql_create_all=metadata.export_as_string(),
+            aggregates=sorted(
+                CassandraAggregate.from_cassandra_metadata(metadata) for metadata in metadata.aggregates.values()
+            ),
+            functions=sorted(
+                CassandraFunction.from_cassandra_metadata(metadata) for metadata in metadata.functions.values()
+            ),
+            tables=sorted(CassandraTable.from_cassandra_metadata(metadata) for metadata in metadata.tables.values()),
+            user_types=sorted(
+                CassandraUserType.from_cassandra_metadata(metadata) for metadata in metadata.user_types.values()
+            ),
+        )
+
+    def iterate_user_types_in_restore_order(self) -> Iterator[CassandraUserType]:
+        pending = {x.name: (x, x.referred_normalized_identifiers()) for x in self.user_types}
+        pending_set = set(pending.keys())
+        while pending:
+            changed = False
+            for user_type_name, (user_type, referred_normalized_identifiers) in list(pending.items()):
+                if pending_set & referred_normalized_identifiers:
+                    continue
+                yield user_type
+                del pending[user_type_name]
+                changed = True
+            if not changed:
+                raise ValueError(f"Loop detected in user types: {pending!r}")
+            pending_set = set(pending.keys())
+
+    def restore(self, cas: CassandraSession) -> None:
+        metadata = cas.cluster_metadata
+        self.restore_if_needed(cas, metadata.keyspaces)
+        keyspace_metadata: cm.KeyspaceMetadata = metadata.keyspaces[self.name]
+        for user_type in self.iterate_user_types_in_restore_order():
+            user_type.restore_in_keyspace(cas, keyspace_metadata)
+        for table in self.tables:
+            table.restore_if_needed(cas, keyspace_metadata.tables)
+        # Functions, aggregates are intentionally handled later
+
+    def restore_post_data(self, cas: CassandraSession) -> None:
+        metadata = cas.cluster_metadata
+        keyspace_metadata: cm.KeyspaceMetadata = metadata.keyspaces[self.name]
+        for resource in itertools.chain(self.functions, self.aggregates):
+            resource.restore_in_keyspace(cas, keyspace_metadata)
+
+        for table in self.tables:
+            table.restore_post_data_in_keyspace(cas, keyspace_metadata)
+
+
+class CassandraSchema(AstacusModel):
+    keyspaces: List[CassandraKeyspace]
+
+    @classmethod
+    def from_cassandra_session(cls, cas: CassandraSession) -> "CassandraSchema":
+        """Retrieve the schema using CassandraSession"""
+        # Cassandra driver updates the schema in the background. Right after connect it's possible the schema hasn't been
+        # retrieved yet, and it appears to be empty. This call should block until the schema has been retrieved, and raise
+        # an exception if the nodes aren't in sync
+        cas.cluster_refresh_schema_metadata(max_schema_agreement_wait=10.0)
+
+        if not cas.cluster_metadata.keyspaces:
+            # there should always be system keyspaces, even when there are no user ones
+            raise ValueError("No keyspaces in schema metadata")
+        return cls(
+            keyspaces=sorted(
+                CassandraKeyspace.from_cassandra_metadata(metadata) for metadata in cas.cluster_metadata.keyspaces.values()
+            )
+        )
+
+    def calculate_hash(self) -> str:
+        """Get hash of the schema.
+
+        This works as simply as it does due to schema-reading
+        functions (from_cassandra*) enforcing ordering by name.
+
+        Based on code review, use of SELECT schema_version FROM
+        system.local is preferrable. This is now used only in tests to
+        ensure the dumping in general works.
+
+        """
+        return hashlib.sha256(self.json().encode("utf-8")).hexdigest()
+
+    def restore_pre_data(self, cas: CassandraSession) -> None:
+        """First part of Cassandra schema restoration.
+
+        Cassandra schema restoration consists of two parts:
+
+        - restore_pre_data is done before any of the snapshot data is
+          moved into place, and its goal is mainly to have the schema
+          correspond to what was in the backup (this function)
+
+        - restore_post_data is done after the restore_pre_data, and
+          actual snapshot restoration + moving of files has been done
+        """
+
+        for keyspace in self.keyspaces:
+            # These may be version dependant, and in general should be recreated
+            # during restore (and-or other configuration applying)
+            if is_system_keyspace(keyspace.name):
+                continue
+            keyspace.restore(cas)
+
+    def restore_post_data(self, cas: CassandraSession) -> None:
+        """Second part of Cassandra schema restoration.
+
+        See restore_pre_data for the flow.
+        """
+        for keyspace in self.keyspaces:
+            # These may be version dependant, and in general should be recreated
+            # during restore (and-or other configuration applying)
+            if is_system_keyspace(keyspace.name):
+                continue
+            keyspace.restore_post_data(cas)

--- a/astacus/common/cassandra/utils.py
+++ b/astacus/common/cassandra/utils.py
@@ -1,0 +1,19 @@
+"""
+Copyright (c) 2021 Aiven Ltd
+See LICENSE for details
+
+Miscellaneous utilities related to CassandraSession
+
+"""
+
+_SYSTEM_KEYSPACES = {
+    "system",
+    # "system_auth", # While technically system keyspace, we want to restore this
+    "system_distributed",
+    "system_schema",
+    "system_traces",
+}
+
+
+def is_system_keyspace(keyspace: str) -> bool:
+    return keyspace in _SYSTEM_KEYSPACES

--- a/astacus/common/exceptions.py
+++ b/astacus/common/exceptions.py
@@ -28,6 +28,10 @@ class NotFoundException(PermanentException):
     pass
 
 
+class MissingSnapshotResultsException(PermanentException):
+    pass
+
+
 # rohmu without compression/encryption does not work; this temporary
 # check is in place until that gets fixed
 

--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -21,6 +21,7 @@ import socket
 # These are the database plugins we support; list is intentionally
 # enum here, as dynamically adding them isn't priority (for now)
 class Plugin(str, Enum):
+    cassandra = "cassandra"
     clickhouse = "clickhouse"
     files = "files"
     m3db = "m3db"
@@ -151,6 +152,26 @@ class SnapshotDownloadRequest(NodeRequest):
 class SnapshotClearRequest(NodeRequest):
     # Files not matching this are not deleted
     root_globs: List[str]
+
+
+# node.cassandra
+
+
+class CassandraSubOp(str, Enum):
+    get_schema_hash = "get-schema-hash"
+    remove_snapshot = "remove-snapshot"
+    restore_snapshot = "restore-snapshot"
+    start_cassandra = "start-cassandra"
+    stop_cassandra = "stop-cassandra"
+    take_snapshot = "take-snapshot"
+
+
+class CassandraStartRequest(NodeRequest):
+    tokens: List[str]
+
+
+class CassandraGetSchemaHashResult(NodeResult):
+    schema_hash: str
 
 
 # coordinator.api

--- a/astacus/common/utils.py
+++ b/astacus/common/utils.py
@@ -205,7 +205,6 @@ def exponential_backoff(
                 if time_left_after_sleep < 0:
                     return None
             logger.debug("exponential_backoff waiting %.2f seconds (retry %d%s)", delay, self.retry, retries_text)
-
             return delay
 
         async def __anext__(self):

--- a/astacus/coordinator/coordinator.py
+++ b/astacus/coordinator/coordinator.py
@@ -19,7 +19,7 @@ from astacus.coordinator.state import coordinator_state, CoordinatorState
 from fastapi import BackgroundTasks, Depends, HTTPException
 from functools import cached_property
 from starlette.datastructures import URL
-from typing import Any, Awaitable, Callable, Dict, Iterator, List, Optional, Type
+from typing import Any, Awaitable, Callable, Dict, Iterator, List, Optional
 from urllib.parse import urlunsplit
 
 import asyncio
@@ -250,7 +250,7 @@ def get_subresult_url(request_url: URL, op_id: int) -> str:
 class SteppedCoordinatorOp(LockedCoordinatorOp):
     attempts: int
     steps: List[Step]
-    step_progress: Dict[Type[Step], Progress]
+    step_progress: Dict[int, Progress]
 
     def __init__(self, *, c: Coordinator = Depends(), attempts: int, steps: List[Step]):
         super().__init__(c=c)
@@ -301,7 +301,7 @@ class SteppedCoordinatorOp(LockedCoordinatorOp):
     @contextlib.contextmanager
     def _progress_handler(self, cluster: Cluster, step: Step) -> Iterator[None]:
         def progress_handler(progress: Progress):
-            self.step_progress[step.__class__] = progress
+            self.step_progress[self.steps.index(step)] = progress
 
         cluster.set_progress_handler(progress_handler)
         try:

--- a/astacus/coordinator/plugins/__init__.py
+++ b/astacus/coordinator/plugins/__init__.py
@@ -6,6 +6,10 @@ from typing import Type
 def get_plugin(plugin: Plugin) -> Type[CoordinatorPlugin]:
     # pylint: disable=import-outside-toplevel
 
+    if plugin == Plugin.cassandra:
+        from .cassandra.plugin import CassandraPlugin
+
+        return CassandraPlugin
     if plugin == Plugin.clickhouse:
         from .clickhouse.plugin import ClickHousePlugin
 

--- a/astacus/coordinator/plugins/cassandra/backup_steps.py
+++ b/astacus/coordinator/plugins/cassandra/backup_steps.py
@@ -1,0 +1,102 @@
+"""Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+
+cassandra backup/restore plugin steps
+
+"""
+
+from .model import CassandraConfigurationNode, CassandraManifest, CassandraManifestNode
+from .utils import get_schema_hash
+from astacus.common import exceptions
+from astacus.common.cassandra.client import CassandraClient, CassandraSession
+from astacus.common.cassandra.schema import CassandraSchema
+from astacus.coordinator.cluster import Cluster
+from astacus.coordinator.plugins.base import Step, StepFailedError, StepsContext
+from dataclasses import dataclass
+from typing import Dict, List
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class CassandraSchemaRetrievalFailureException(exceptions.TransientException):
+    pass
+
+
+def _retrieve_manifest_from_cassandra(
+    cas: CassandraSession, config_nodes: List[CassandraConfigurationNode]
+) -> CassandraManifest:
+    host_id_to_node: Dict[str, CassandraManifestNode] = {}
+    for token, host in cas.cluster_metadata.token_map.token_to_host_owner.items():
+        node = host_id_to_node.get(host.host_id)
+        if node is None:
+            # host.listen_address is for the local host in system.local
+            # host.broadcast_address is for the peers in system.peers ('peer' field)
+            node = CassandraManifestNode(
+                address=host.address,
+                host_id=host.host_id,
+                listen_address=host.listen_address or host.broadcast_address,
+                rack=host.rack,
+                tokens=[],
+            )
+            host_id_to_node[host.host_id] = node
+            # Assume Murmur3Token
+        node.tokens.append(str(token.value))
+
+    logger.debug("Cassandra nodes: %r", list(host_id_to_node.values()))
+    nodes = []
+    for configured_node in config_nodes:
+        matching_manifest_nodes = [
+            manifest_node
+            for manifest_node in host_id_to_node.values()
+            if manifest_node.matches_configuration_node(configured_node)
+        ]
+
+        # Ensure it matches only 1
+        if len(matching_manifest_nodes) == 0:
+            raise ValueError(f"No matching cluster node for {configured_node}")
+        if len(matching_manifest_nodes) > 1:
+            raise ValueError(f"Too many matching cluster nodes for {configured_node}: {matching_manifest_nodes}")
+
+        # And the matched one hasn't been matched before
+        if matching_manifest_nodes[0] in nodes:
+            raise ValueError(f"{matching_manifest_nodes[0]} matched more than once")
+
+        nodes.append(matching_manifest_nodes[0])
+
+    if len(nodes) != len(host_id_to_node):
+        raise ValueError(f"Incorrect node count: {len(nodes)} <> {len(host_id_to_node)}")
+
+    schema = CassandraSchema.from_cassandra_session(cas)
+    return CassandraManifest(cassandra_schema=schema, nodes=nodes)
+
+
+@dataclass
+class RetrieveSchemaHashStep(Step[str]):
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> str:
+        schema_hash, err = await get_schema_hash(cluster=cluster)
+        if not schema_hash:
+            raise CassandraSchemaRetrievalFailureException(err)
+        return schema_hash
+
+
+@dataclass
+class AssertSchemaUnchanged(Step[None]):
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
+        schema_hash, err = await get_schema_hash(cluster=cluster)
+        if not schema_hash:
+            raise CassandraSchemaRetrievalFailureException(err)
+        if schema_hash != context.get_result(RetrieveSchemaHashStep):
+            raise StepFailedError("schema hash mismatch snapshot")
+
+
+@dataclass
+class PrepareCassandraManifestStep(Step[Dict]):
+    client: CassandraClient
+    nodes: List[CassandraConfigurationNode]
+
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> Dict:
+        result = await self.client.run_sync(_retrieve_manifest_from_cassandra, self.nodes)
+        assert result
+        return result.dict()

--- a/astacus/coordinator/plugins/cassandra/model.py
+++ b/astacus/coordinator/plugins/cassandra/model.py
@@ -1,0 +1,48 @@
+"""Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+
+cassandra backup/restore plugin models
+
+"""
+
+from astacus.common.cassandra.schema import CassandraSchema
+from astacus.common.utils import AstacusModel
+from pydantic import root_validator
+from typing import List, Optional
+from uuid import UUID
+
+
+class CassandraConfigurationNode(AstacusModel):
+    # The configured node order has to be identified _somehow_;
+    # otherwise, we cannot map the same data to same set of
+    # tokens. One of these is required.
+    address: Optional[str]
+    host_id: Optional[UUID]
+    listen_address: Optional[str]
+    tokens: Optional[List[str]]
+
+    @classmethod
+    @root_validator
+    def ensure_identifier_provided(cls, values: dict) -> dict:
+        assert any(values.get(k) for k in ["address", "host_id", "listen_address", "tokens"])
+        return values
+
+
+class CassandraManifestNode(AstacusModel):
+    address: str
+    host_id: UUID
+    listen_address: str
+    rack: str
+    tokens: List[str]
+
+    def matches_configuration_node(self, node: CassandraConfigurationNode) -> bool:
+        for attribute in ["address", "host_id", "listen_address", "tokens"]:
+            other_value = getattr(node, attribute)
+            if other_value and getattr(self, attribute) != other_value:
+                return False
+        return True
+
+
+class CassandraManifest(AstacusModel):
+    cassandra_schema: CassandraSchema
+    nodes: List[CassandraManifestNode]

--- a/astacus/coordinator/plugins/cassandra/plugin.py
+++ b/astacus/coordinator/plugins/cassandra/plugin.py
@@ -1,0 +1,107 @@
+"""Copyright (c) 2020 Aiven Ltd
+See LICENSE for details
+
+cassandra backup/restore plugin
+
+"""
+
+from .model import CassandraConfigurationNode
+from .utils import run_subop
+from astacus.common import ipc
+from astacus.common.cassandra.client import CassandraClient
+from astacus.common.cassandra.config import CassandraClientConfiguration, SNAPSHOT_NAME
+from astacus.coordinator.cluster import Cluster
+from astacus.coordinator.plugins import base
+from astacus.coordinator.plugins.base import CoordinatorPlugin, OperationContext, Step, StepFailedError, StepsContext
+from astacus.coordinator.plugins.cassandra import backup_steps, restore_steps
+from dataclasses import dataclass
+from typing import List, Optional
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CassandraSubOpStep(Step[None]):
+    op: ipc.CassandraSubOp
+
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
+        await run_subop(cluster, self.op, result_class=ipc.NodeResult)
+        # We intentionally return always None so this same (class )
+        # can be reused in set of plugin steps with different
+        # parameters; if the operation fails, we throw exception
+        # instead
+
+
+@dataclass
+class ValidateConfigurationStep(Step[None]):
+    nodes: List[CassandraConfigurationNode]
+
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
+        cnode_count = len(self.nodes)
+        node_count = len(cluster.nodes)
+        if cnode_count != node_count:
+            diff = node_count - cnode_count
+            raise StepFailedError(f"{node_count} nodes, yet {cnode_count} nodes in the cassandra nodes - diff:{diff}")
+
+
+class CassandraPlugin(CoordinatorPlugin):
+    client: CassandraClientConfiguration
+    nodes: Optional[List[CassandraConfigurationNode]]
+    restore_start_timeout: int = 3600
+
+    def get_backup_steps(self, *, context: OperationContext) -> List[Step]:
+        nodes = self.nodes or [CassandraConfigurationNode(listen_address=self.client.get_listen_address())]
+        client = CassandraClient(self.client)
+        # first *: keyspace name; second *: table name
+        snapshot_root_globs = [
+            f"data/*/*/snapshots/{SNAPSHOT_NAME}/manifest.json",
+            f"data/*/*/snapshots/{SNAPSHOT_NAME}/*.db",
+            f"data/*/*/snapshots/{SNAPSHOT_NAME}/*.txt",
+            f"data/*/*/snapshots/{SNAPSHOT_NAME}/*.cql",
+        ]
+
+        return [
+            ValidateConfigurationStep(nodes=nodes),
+            backup_steps.RetrieveSchemaHashStep(),
+            backup_steps.PrepareCassandraManifestStep(client=client, nodes=nodes),
+            CassandraSubOpStep(op=ipc.CassandraSubOp.remove_snapshot),
+            CassandraSubOpStep(op=ipc.CassandraSubOp.take_snapshot),
+            backup_steps.AssertSchemaUnchanged(),
+            base.SnapshotStep(snapshot_root_globs=snapshot_root_globs),
+            base.ListHexdigestsStep(hexdigest_storage=context.hexdigest_storage),
+            base.UploadBlocksStep(storage_name=context.storage_name),
+            CassandraSubOpStep(op=ipc.CassandraSubOp.remove_snapshot),
+            base.UploadManifestStep(
+                json_storage=context.json_storage,
+                plugin=ipc.Plugin.cassandra,
+                plugin_manifest_step=backup_steps.PrepareCassandraManifestStep,
+            ),
+        ]
+
+    def get_restore_steps(self, *, context: OperationContext, req: ipc.RestoreRequest) -> List[Step]:
+        # The nodes are not really used for now; perhaps they should be, at some point?
+        # their validity is checked just for symmetry with backup, for now.
+        nodes = self.nodes or [CassandraConfigurationNode(listen_address=self.client.get_listen_address())]
+        client = CassandraClient(self.client)
+
+        # TBD: partial_restore_nodes should be probably passed to about all steps?
+        return [
+            ValidateConfigurationStep(nodes=nodes),
+            base.BackupNameStep(json_storage=context.json_storage, requested_name=req.name),
+            base.BackupManifestStep(json_storage=context.json_storage),
+            restore_steps.ParsePluginManifestStep(),
+            # Start cassandra + set schema + stop it
+            restore_steps.StartCassandraStep(partial_restore_nodes=req.partial_restore_nodes),
+            restore_steps.WaitCassandraUpStep(duration=self.restore_start_timeout),
+            restore_steps.RestorePreDataStep(client=client),
+            CassandraSubOpStep(op=ipc.CassandraSubOp.stop_cassandra),
+            # Restore snapshot
+            base.RestoreStep(storage_name=context.storage_name, partial_restore_nodes=req.partial_restore_nodes),
+            CassandraSubOpStep(op=ipc.CassandraSubOp.restore_snapshot),
+            # restart cassandra and do the final actions with data available
+            restore_steps.StartCassandraStep(partial_restore_nodes=req.partial_restore_nodes),
+            restore_steps.WaitCassandraUpStep(duration=self.restore_start_timeout),
+            restore_steps.RestorePostDataStep(client=client),
+        ]

--- a/astacus/coordinator/plugins/cassandra/restore_steps.py
+++ b/astacus/coordinator/plugins/cassandra/restore_steps.py
@@ -1,0 +1,93 @@
+"""Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+
+cassandra backup/restore plugin steps
+
+"""
+
+from .model import CassandraManifest
+from .utils import get_schema_hash, run_subop
+from astacus.common import ipc, utils
+from astacus.common.cassandra.client import CassandraClient
+from astacus.coordinator.cluster import Cluster
+from astacus.coordinator.config import CoordinatorNode
+from astacus.coordinator.plugins.base import (
+    BackupManifestStep,
+    get_node_to_backup_index,
+    Step,
+    StepFailedError,
+    StepsContext,
+)
+from dataclasses import dataclass
+from typing import List, Optional
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ParsePluginManifestStep(Step[CassandraManifest]):
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> CassandraManifest:
+        backup_manifest = context.get_result(BackupManifestStep)
+        return CassandraManifest.parse_obj(backup_manifest.plugin_data)
+
+
+@dataclass
+class StartCassandraStep(Step[None]):
+    partial_restore_nodes: Optional[List[ipc.PartialRestoreRequestNode]]
+
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
+        backup_manifest = context.get_result(BackupManifestStep)
+
+        node_to_backup_index = get_node_to_backup_index(
+            partial_restore_nodes=self.partial_restore_nodes,
+            snapshot_results=backup_manifest.snapshot_results,
+            nodes=cluster.nodes,
+        )
+
+        reqs: List[ipc.NodeRequest] = []
+        nodes: List[CoordinatorNode] = []
+        plugin_manifest = context.get_result(ParsePluginManifestStep)
+        for node_index, backup_index in enumerate(node_to_backup_index):
+            if backup_index is None:
+                continue
+            nodes.append(cluster.nodes[node_index])
+            reqs.append(ipc.CassandraStartRequest(tokens=plugin_manifest.nodes[backup_index].tokens))
+
+        await run_subop(cluster, ipc.CassandraSubOp.start_cassandra, nodes=nodes, reqs=reqs, result_class=ipc.NodeResult)
+
+
+@dataclass
+class WaitCassandraUpStep(Step[None]):
+    duration: int
+
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
+        last_err = None
+        async for _ in utils.exponential_backoff(initial=1, maximum=60, duration=self.duration):
+            current_hash, err = await get_schema_hash(cluster=cluster)
+            if current_hash:
+                return
+            if err:
+                last_err = err
+        raise StepFailedError(f"Cassandra did not successfully come up: {last_err}")
+
+
+@dataclass
+class RestorePreDataStep(Step[None]):
+    client: CassandraClient
+
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
+        # TBD: How does partial restore work in this case?
+        manifest = context.get_result(ParsePluginManifestStep)
+        await self.client.run_sync(manifest.cassandra_schema.restore_pre_data)
+
+
+@dataclass
+class RestorePostDataStep(Step[None]):
+    client: CassandraClient
+
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
+        # TBD: How does partial restore work in this case?
+        manifest = context.get_result(ParsePluginManifestStep)
+        await self.client.run_sync(manifest.cassandra_schema.restore_post_data)

--- a/astacus/coordinator/plugins/cassandra/utils.py
+++ b/astacus/coordinator/plugins/cassandra/utils.py
@@ -1,0 +1,51 @@
+"""Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+
+cassandra backup/restore plugin utilities
+
+"""
+
+
+from astacus.common import ipc
+from astacus.coordinator.cluster import Cluster
+from astacus.coordinator.config import CoordinatorNode
+from astacus.coordinator.plugins.base import StepFailedError
+from typing import List, Optional, Tuple, Type, TypeVar
+
+NR = TypeVar("NR", bound=ipc.NodeResult)
+
+
+async def run_subop(
+    cluster: Cluster,
+    subop: ipc.CassandraSubOp,
+    *,
+    nodes: Optional[List[CoordinatorNode]] = None,
+    req: Optional[ipc.NodeRequest] = None,
+    reqs: Optional[List[ipc.NodeRequest]] = None,
+    result_class: Type[NR],
+) -> List[NR]:
+    if not req and not reqs:
+        req = ipc.NodeRequest()
+    start_results = await cluster.request_from_nodes(
+        f"cassandra/{subop.value}",
+        method="post",
+        caller="Cassandra.run_subop",
+        req=req,
+        reqs=reqs,
+        nodes=nodes,
+    )
+    if not start_results:
+        raise StepFailedError(f"Starting of cassandra subop {subop} failed")
+    return await cluster.wait_successful_results(start_results=start_results, result_class=result_class)
+
+
+async def get_schema_hash(cluster: Cluster) -> Tuple[str, str]:
+    hashes = [
+        x.schema_hash
+        for x in await run_subop(cluster, ipc.CassandraSubOp.get_schema_hash, result_class=ipc.CassandraGetSchemaHashResult)
+    ]
+    if not hashes:
+        return "", "Unable to retrieve schema hash at all"
+    if len(set(hashes)) != 1:
+        return "", f"Multiple schema hashes present: {hashes}"
+    return hashes[0], ""

--- a/astacus/node/cassandra.py
+++ b/astacus/node/cassandra.py
@@ -1,0 +1,178 @@
+"""
+
+Copyright (c) 2021 Aiven Ltd
+See LICENSE for details
+
+Cassandra handling that is run on every node in the Cluster
+
+"""
+
+from .node import NodeOp
+from astacus.common import ipc
+from astacus.common.cassandra.client import CassandraClient
+from astacus.common.cassandra.config import SNAPSHOT_NAME
+from astacus.common.cassandra.utils import is_system_keyspace
+from astacus.common.exceptions import TransientException
+
+import contextlib
+import logging
+import shutil
+import subprocess
+import tempfile
+import yaml
+
+logger = logging.getLogger(__name__)
+
+SNAPSHOT_GLOB = f"data/*/*/snapshots/{SNAPSHOT_NAME}"
+
+
+class SimpleCassandraSubOp(NodeOp):
+    """
+    Generic class to handle no arguments in + no output out case subops.
+
+    Due to that, it does not (really) care about request, and as far
+    as result goes it only cares about progress.
+    """
+
+    def start(self, *, req: ipc.NodeRequest, subop: ipc.CassandraSubOp) -> NodeOp.StartResult:
+        self.req = req
+        assert self.config.cassandra
+        return self.start_op(
+            op_name="cassandra",
+            op=self,
+            fun={
+                ipc.CassandraSubOp.remove_snapshot: self.remove_snapshot,
+                ipc.CassandraSubOp.restore_snapshot: self.restore_snapshot,
+                ipc.CassandraSubOp.stop_cassandra: self.stop_cassandra,
+                ipc.CassandraSubOp.take_snapshot: self.take_snapshot,
+            }[subop],
+        )
+
+    def remove_snapshot(self) -> None:
+        """This is used to remove the current snapshot (if any).
+
+        It is used as prelude for actual Astacus snapshot of the files
+        and after the backup has completed.
+
+        Note that Cassandra does not do any internal bookkeeping of
+        the snapshots so the rmtrees are enough.
+        """
+        progress = self.result.progress
+        progress.add_total(1)
+        todo = list(self.config.root.glob(SNAPSHOT_GLOB))
+        progress.add_success()
+        progress.add_total(len(todo))
+        for snapshotpath in todo:
+            shutil.rmtree(snapshotpath)
+            progress.add_success()
+        progress.done()
+
+    def restore_snapshot(self) -> None:
+        """This is used to restore the snapshot files into place, with Cassandra offline."""
+        # TBD: Delete extra data (current cashew doesn't do it, but we could)
+
+        # Move files from Astacus snapshot directories to the actual data directories
+        progress = self.result.progress
+        table_snapshots = list(self.config.root.glob(SNAPSHOT_GLOB))
+        progress.add_total(len(table_snapshots))
+
+        for table_snapshot in table_snapshots:
+            parts = table_snapshot.parts
+            # -2 = snapshots, -1 = name of the snapshots
+            table_name_and_id = parts[-3]
+            keyspace_name = parts[-4]
+            if is_system_keyspace(keyspace_name):
+                progress.add_success()
+                continue
+
+            table_name, _ = table_name_and_id.rsplit("-", 1)
+
+            # This could be more efficient too; oh well.
+            keyspace_path = table_snapshot.parents[2]
+            table_paths = list(keyspace_path.glob(f"{table_name}-*"))
+            assert len(table_paths) >= 1, f"NO tables with prefix {table_name}- found in {keyspace_path}!"
+            if len(table_paths) > 1:
+                # Prefer the one that isn't table_name_and_id
+                table_paths = [p for p in table_paths if p.name != table_name_and_id]
+            assert len(table_paths) == 1
+
+            table_path = table_paths[0]
+
+            # Ensure destination path is empty except for potential directories (e.g. backups/)
+            # This should never have anything
+            existing_files = [file_path for file_path in table_path.glob("*") if file_path.is_file()]
+            assert not existing_files, f"Files found in {table_name}: {existing_files}"
+
+            for file_path in table_snapshot.glob("*"):
+                # TBD if we should filter something?
+                file_path.rename(table_path / file_path.name)
+
+            progress.add_success()
+
+        self.result.progress.done()
+
+    def stop_cassandra(self) -> None:
+        assert self.config.cassandra
+        subprocess.run(self.config.cassandra.stop_command, check=True)
+        self.result.progress.done()
+
+    def take_snapshot(self) -> None:
+        assert self.config.cassandra
+        cmd = self.config.cassandra.nodetool_command[:]
+        cmd.extend(["snapshot", "-t", SNAPSHOT_NAME])
+        subprocess.run(cmd, check=True)
+        self.result.progress.done()
+
+
+class CassandraStartOp(NodeOp):
+    req: ipc.CassandraStartRequest
+
+    def start(self, *, req: ipc.CassandraStartRequest) -> NodeOp.StartResult:
+        self.req = req
+        return self.start_op(op_name="cassandra", op=self, fun=self.start_cassandra)
+
+    def start_cassandra(self) -> None:
+        progress = self.result.progress
+        progress.add_total(3)
+
+        assert self.config.cassandra
+        config_path = self.config.cassandra.client.config_path
+        assert config_path
+
+        with config_path.open() as config_read_fh:
+            config = yaml.safe_load(config_read_fh)
+        progress.add_success()
+
+        config["auto_bootstrap"] = False
+        config["initial_token"] = ", ".join(self.req.tokens)
+        with tempfile.NamedTemporaryFile(mode="w") as config_fh:
+            yaml.safe_dump(config, config_fh)
+            config_fh.flush()
+            progress.add_success()
+
+            subprocess.run(self.config.cassandra.start_command + [config_fh.name], check=True)
+            progress.add_success()
+
+        progress.done()
+
+
+class CassandraGetSchemaHashOp(NodeOp):
+    def start(self, *, req: ipc.NodeRequest) -> NodeOp.StartResult:
+        self.req = req
+        assert self.config.cassandra
+        return self.start_op(op_name="cassandra", op=self, fun=self.get_schema_hash)
+
+    def create_result(self) -> ipc.CassandraGetSchemaHashResult:
+        return ipc.CassandraGetSchemaHashResult(schema_hash="")
+
+    def _get_schema_hash(self) -> str:
+        assert self.config.cassandra
+        with CassandraClient(self.config.cassandra.client).connect() as cas:
+            rows = cas.execute("SELECT schema_version FROM system.local")
+            return rows[0][0]
+
+    def get_schema_hash(self) -> None:
+        """This is used to get hash of the schema as seen by this node."""
+        with contextlib.suppress(TransientException):
+            self.result.schema_hash = self._get_schema_hash()
+        self.result.progress.done()

--- a/astacus/node/config.py
+++ b/astacus/node/config.py
@@ -3,13 +3,14 @@ Copyright (c) 2020 Aiven Ltd
 See LICENSE for details
 """
 
+from astacus.common.cassandra.config import CassandraClientConfiguration
 from astacus.common.rohmustorage import RohmuConfig
 from astacus.common.statsd import StatsdConfig
 from astacus.common.utils import AstacusModel
 from fastapi import Request
 from pathlib import Path
-from pydantic import DirectoryPath, Field
-from typing import Optional
+from pydantic import DirectoryPath, Field, validator
+from typing import List, Optional
 
 APP_KEY = "node_config"
 
@@ -19,6 +20,26 @@ class NodeParallel(AstacusModel):
     downloads: int = 1
     hashes: int = 1
     uploads: int = 1
+
+
+class CassandraNodeConfig(AstacusModel):
+    # Used in subop=get-schema-hash
+    client: CassandraClientConfiguration
+
+    # Nodetool is used to take snapshots in in cassandra subop=refresh-snapshot
+    # (arguments passed as-is to subprocess.run)
+    nodetool_command: List[str]
+
+    # Cassandra start/stop are used in cassandra subop start-cassandra / stop-cassandra
+    # (arguments passed as-is to subprocess.run)
+    start_command: List[str]
+    stop_command: List[str]
+
+    @classmethod
+    @validator("client")
+    def ensure_config_path_specified(cls, v):
+        assert v.config_path, "config_path must be specified for client in node section"
+        return v
 
 
 class NodeConfig(AstacusModel):
@@ -38,6 +59,10 @@ class NodeConfig(AstacusModel):
     statsd: Optional[StatsdConfig] = None
 
     parallel: NodeParallel = Field(default_factory=NodeParallel)
+
+    # Cassandra configuration is optional; for now, in node part of
+    # the code, there are no plugins. (This may change later.)
+    cassandra: Optional[CassandraNodeConfig]
 
 
 def node_config(request: Request) -> NodeConfig:

--- a/astacus/node/snapshotter.py
+++ b/astacus/node/snapshotter.py
@@ -192,6 +192,7 @@ class Snapshotter:
 
         src_dirs, src_files = self._list_dirs_and_files(self.src)
         progress.start(1)
+        changes = 0
         if self.src == self.dst:
             # The src=dst mode should be used if and only if it is
             # known that files will not disappear between snapshot and
@@ -205,7 +206,7 @@ class Snapshotter:
             dst_dirs, dst_files = self._list_dirs_and_files(self.dst)
 
             # Create missing directories
-            changes = self._snapshot_create_missing_directories(src_dirs=src_dirs, dst_dirs=dst_dirs)
+            changes += self._snapshot_create_missing_directories(src_dirs=src_dirs, dst_dirs=dst_dirs)
             progress.add_success()
 
             # Remove extra files

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+ coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 0%
+       # advanced settings
+        if_ci_failed: error #success, failure, error, ignore
+        informational: true
+        only_pulls: false
+        if_not_found: failure

--- a/doc/design/cassandra.md
+++ b/doc/design/cassandra.md
@@ -1,0 +1,88 @@
+# Cassandra backup/restore mechanics #
+
+There is a large number of existing projects that implement Cassandra
+backups, but none of them fit quite the criteria we wanted:
+
+- reasonably stand-alone and automatable
+- data-at-reste security built in
+- compression
+- deduplication
+
+and due to that the Cassandra support implementation for Astacus was
+started.
+
+## Cassandra backup format
+
+Astacus backups consist of generic manifest, and then per-node snapshot
+results, as well as plugin specific metadata.
+
+We store Cassandra schema in the plugin specific metadata, and take
+Cassandra snapshot of all nodes being backed up and back that up using the
+generic Astacus mechanism.
+
+References in the code:
+- astacus/common/ipc.py (Generic backup manifest)
+- astacus/coordinator/plugins/cassandra/ (Cassandra plugin specific parts)
+
+## Backup process
+
+See the Cassandra plugin for details, but basically we do following steps
+(and as per Astacus philosophy, steps are either retried or whole operation
+fails if something unexpected occurs):
+
+1. validate configuration seems sane and matches cluster
+
+1. ensure hash of schema of all nodes is consistent
+
+1. retrieve actual schema from current node
+
+1. remove old Cassandra snapshot (if any)
+
+1. take Cassandra snapshot
+
+1. retrieve hash of the schema from all nodes and ensure it matches hash
+   from the first step
+
+1. (common Astacus code) take Astacus snapshot of Cassandra snapshot (=
+   calculate hashes of all files in Cassandra snapshot directories that
+   have changed since previous iteration)
+
+1. (common Astacus code) check object storage for which hashes already
+   exist there
+
+1. (common Astacus code) upload the objects that are missing from the
+   object storage to the cloud
+
+1. upload backup manifest
+
+## Restore process
+
+1. validate configuration seems sane and matches cluster
+
+1. retrieve backup manifest
+
+1. parse plugin-specific part of the manifest
+
+1. start Cassandra on the nodes, with auto bootstrap disabled, and initial
+   tokens based on backup manifest (= call configured start script with the
+   edited configuration file)
+
+1. wait until Cassandra nodes are up
+
+1. (ensure hash of schema of all nodes is consistent - TBD, we don't do
+   this at the moment, is it worth doing?)
+
+1. pre-data-restore restore schema to the cluster (e.g. normal tables)
+
+1. power off Cassandras
+
+1. (common Astacus code) restore the snapshotted data to the nodes
+
+1. move the tables' data from snapshot directories to the actual tables'
+   directories
+
+1. start Cassandra on the nodes again
+
+1. wait until Cassandra nodes are up
+
+1. post-data-restore restore schema to the cluster (e.g. indexes)

--- a/examples/astacus-cassandra-gcs.yaml
+++ b/examples/astacus-cassandra-gcs.yaml
@@ -1,0 +1,92 @@
+#
+# This is single-node example of how Cassandra plugin works; for more
+# realistic cases, coordinator should be specified with list of nodes
+# instead of the local default that is produced from the configuration
+# file.
+#
+
+coordinator:
+ nodes:
+ - url: http://localhost:5515/node
+ object_storage_cache: /tmp/astacus/cache
+ plugin: cassandra
+ plugin_config:
+  nodes:
+   # This is used to identify the node(s)
+    - listen_address: fda7:a938:5bfe:5fa6:0:3b5:aacd:f2bb
+    - listen_address: fda7:a938:5bfe:5fa6:0:3b5:aacd:f2bc
+
+  # This is how (some node) of the cluster can be contacted
+  client:
+   # this is optional, but convenient to get native_transport_port
+   #config_path: example/cassandra-conf.yaml
+   #default
+   hostnames:
+    - 127.0.0.1
+   #port can be set, but it can be also read from file
+   port: 27140
+   username: aiven
+   password: REDACTED
+
+# with Cassandra, root_link == root works best, as no need to have
+# dangling symlinks in the link directory
+node:
+ root: /tmp/astacus/cassandra
+ root_link: /tmp/astacus/cassandra
+ cassandra:
+  nodetool_command: ["nodetool"]
+  start_command: ["systemctl", "start", "cassandra"]
+  stop_command: ["systemctl", "stop", "cassandra"]
+  client:
+   # this is mandatory for restore to work, so no point specifying anything else
+   config_path: example/cassandra-conf.yaml
+   username: aiven
+   password: REDACTED
+
+object_storage:
+  compression:
+    algorithm: zstd
+  default_storage: storage1
+  encryption_key_id: key1
+  encryption_keys:
+    key1:
+      private: '-----BEGIN PRIVATE KEY-----
+
+        REDACTED-----END PRIVATE KEY-----
+
+        '
+      public: '-----BEGIN PUBLIC KEY-----
+
+        REDACTED
+
+        -----END PUBLIC KEY-----
+
+        '
+  storages:
+    storage1:
+      bucket_name: bucket1
+      credentials:
+        auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
+        auth_uri: https://accounts.google.com/o/oauth2/auth
+        client_email: REDACTED
+        client_id: '1234567890'
+        client_x509_cert_url: https://www.googleapis.com/robot/v1/metadata/x509/REDACTED
+        private_key: '-----BEGIN PRIVATE KEY-----
+
+          REDACTED
+
+          -----END PRIVATE KEY-----
+
+          '
+        private_key_id: REDACTED
+        project_id: project1
+        token_uri: https://accounts.google.com/o/oauth2/token
+        type: service_account
+      prefix: storage1
+      project_id: project1
+      storage_type: google
+  temporary_directory: /tmp/astacus/storage-tmp
+
+uvicorn:
+ log_level: debug
+ reload: true

--- a/examples/astacus-cassandra-local.yaml
+++ b/examples/astacus-cassandra-local.yaml
@@ -1,0 +1,59 @@
+#
+# This is single-node example of how Cassandra plugin works; for more
+# realistic cases, coordinator should be specified with list of nodes
+# instead of the local default that is produced from the configuration
+# file.
+#
+
+coordinator:
+ nodes:
+ - url: http://localhost:5515/node
+ object_storage_cache: /tmp/astacus/cache
+ plugin: cassandra
+ plugin_config:
+  #nodes:
+  # # This is used to identify the node(s)
+  # - listen_address: fda7:a938:5bfe:5fa6:0:3b5:aacd:f2bb
+  # - listen_address: fda7:a938:5bfe:5fa6:0:3b5:aacd:f2bc
+  # ..
+
+  # This is how (some node) of the cluster can be contacted
+  client:
+   # this is optional, but convenient to get native_transport_port
+   config_path: example/cassandra-conf.yaml
+   #default
+   #hostnames:
+   # - 127.0.0.1
+   #port can be set, but it can be also read from file
+   #port: 27140
+   username: aiven
+   password: REDACTED
+
+# with Cassandra, root_link == root works best, as no need to have
+# dangling symlinks in the link directory
+node:
+ root: /tmp/astacus/cassandra
+ root_link: /tmp/astacus/cassandra
+ cassandra:
+  nodetool_command: ["nodetool"]
+  start_command: ["systemctl", "start", "cassandra"]
+  stop_command: ["systemctl", "stop", "cassandra"]
+  client:
+   # this is mandatory for restore to work, so no point specifying anything else
+   config_path: example/cassandra-conf.yaml
+   username: aiven
+   password: REDACTED
+
+object_storage:
+ temporary_directory: /tmp/astacus/backup-tmp
+ default_storage: x
+ compression:
+  algorithm: zstd
+ storages:
+  x:
+   storage_type: local
+   directory: /tmp/astacus/backup
+
+uvicorn:
+ log_level: debug
+ reload: true

--- a/examples/cassandra-conf.yaml
+++ b/examples/cassandra-conf.yaml
@@ -1,0 +1,8 @@
+# This is example cassandra config file - obviously there should be
+# more than what is here, but this is what Astacus uses for
+# configuration via config file
+#
+# (if chosen - these can be also supplied explicitly).
+
+listen_address: fda7:a938:5bfe:5fa6:0:3b5:aacd:f2bb
+native_transport_port: 27140

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,6 +20,12 @@ warn_unused_ignores = True
 # (This is quite painful to do though, TBD later)
 #disallow_untyped_decorators = True
 
+# Any subclassing is probably an error
+disallow_subclassing_any = true
+
+# This codebase should be typed
+#disallow_incomplete_defs = true
+#disallow_untyped_defs = true
 
 # configure pydantic.mypy plugin
 [pydantic-mypy]
@@ -40,20 +46,39 @@ warn_required_dynamic_aliases=True
 
 # Ignores start here (toml format would be nicer but guess this works)
 
-[mypy-systemd.*]
+[mypy-astacus.proto.*]
+ignore_errors = True
+
+[mypy-cassandra.*]
 ignore_missing_imports = True
 
 [mypy-google.protobuf.*]
 ignore_errors = True
 
-[mypy-astacus.proto.*]
-ignore_errors = True
-
 [mypy-graphlib.*]
 ignore_missing_imports = True
 
+# types-kazoo does not unfortunately fix this
 [mypy-kazoo.*]
 ignore_missing_imports = True
 
+# httpcore dependency
 [mypy-h11.*]
 ignore_missing_imports = True
+
+[mypy-systemd.*]
+ignore_missing_imports = True
+
+# TBD: When someone has time, implement these for whole codebase
+
+[mypy-astacus.common.cassandra.*]
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+
+[mypy-astacus.coordinator.plugins.cassandra.*]
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+
+[mypy-astacus.node.cassandra]
+disallow_incomplete_defs = true
+disallow_untyped_defs = true

--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -25,3 +25,4 @@ pytest-watch
 types-PyYAML
 types-requests
 types-tabulate
+types-urllib3

--- a/tests/unit/common/cassandra/test_client.py
+++ b/tests/unit/common/cassandra/test_client.py
@@ -1,0 +1,67 @@
+"""
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+
+from astacus.common.cassandra.config import CassandraClientConfiguration
+
+import pytest
+
+
+@pytest.fixture(name="client_module", scope="session")
+def fixture_client_module():
+    return pytest.importorskip("astacus.common.cassandra.client", reason="Cassandra driver is not available")
+
+
+def test_cassandra_session(client_module, mocker):
+    ccluster = mocker.MagicMock()
+    csession = mocker.MagicMock()
+    session = client_module.CassandraSession(cluster=ccluster, session=csession)
+
+    ccluster.metadata = 42
+    assert session.cluster_metadata == 42
+
+    session.cluster_refresh_schema_metadata(max_schema_agreement_wait=7.0)
+    assert ccluster.refresh_schema_metadata.called_with(max_schema_agreement_wait=7.0)
+
+    test_multi_statement = """
+first
+    part;
+
+
+second!;
+"""
+
+    session.execute_on_all(test_multi_statement)
+    assert len(csession.execute.mock_calls) == 2
+
+
+def create_client(client_module, mocker, ssl=False):
+    mocker.patch.object(client_module, "Cluster")
+    mocker.patch.object(client_module, "WhiteListRoundRobinPolicy")
+
+    config = CassandraClientConfiguration(
+        hostnames=["none"],
+        port=42,
+        username="dummy",
+        password="",
+        ca_cert_path="/path" if ssl else None,
+    )
+    return client_module.CassandraClient(config)
+
+
+@pytest.mark.parametrize("ssl", [False, True])
+def test_cassandra_client(client_module, mocker, ssl):
+    client: client_module.CassandraClient = create_client(client_module, mocker, ssl=ssl)
+    with client.connect() as session:
+        assert isinstance(session, client_module.CassandraSession)
+
+
+@pytest.mark.asyncio
+async def test_cassandra_client_run(client_module, mocker):
+    client = create_client(client_module, mocker)
+
+    def test_fun(cas):
+        return 42
+
+    assert await client.run_sync(test_fun) == 42

--- a/tests/unit/common/cassandra/test_schema.py
+++ b/tests/unit/common/cassandra/test_schema.py
@@ -1,0 +1,106 @@
+"""
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+
+import pytest
+
+# pylint: disable=protected-access
+
+
+@pytest.fixture(name="schema", scope="session")
+def fixture_schema():
+    return pytest.importorskip("astacus.common.cassandra.schema", reason="Cassandra driver is not available")
+
+
+def test_schema(schema, mocker):
+
+    cut = schema.CassandraUserType(name="cut", cql_create_self="CREATE-USER-TYPE", field_types=["type1", "type2"])
+    cfunction = schema.CassandraFunction(name="cf", cql_create_self="CREATE-FUNCTION", argument_types=["atype1", "atype2"])
+
+    cagg = schema.CassandraAggregate(
+        name="cagg",
+        cql_create_self="CREATE-AGGREGATE",
+        argument_types=["aggtype1", "aggtype2"],
+    )
+
+    cindex = schema.CassandraIndex(name="cindex", cql_create_self="CREATE-INDEX")
+
+    ctrigger = schema.CassandraTrigger(name="ctrigger", cql_create_self="CREATE-TRIGGER")
+
+    cmv = schema.CassandraIndex(name="cmv", cql_create_self="CREATE-MATERIALIZED-VIEW")
+
+    ctable = schema.CassandraTable(
+        name="ctable", cql_create_self="CREATE-TABLE", indexes=[cindex], materialized_views=[cmv], triggers=[ctrigger]
+    )
+
+    cks = schema.CassandraKeyspace(
+        name="cks",
+        cql_create_all="CREATE-KEYSPACE-ALL",
+        cql_create_self="CREATE-KEYSPACE",
+        aggregates=[cagg],
+        functions=[cfunction],
+        tables=[ctable],
+        user_types=[cut],
+    )
+
+    cks_system = schema.CassandraKeyspace(
+        name="system",
+        cql_create_all="CREATE-SYSTEM-KEYSPACE-ALL",
+        cql_create_self="CREATE-SYSTEM-KEYSPACE",
+        aggregates=[],
+        functions=[],
+        tables=[],
+        user_types=[],
+    )
+
+    cs = schema.CassandraSchema(keyspaces=[cks, cks_system])
+
+    # If the content above changes - or something in the schema hash
+    # calculation side changes, this hash needs to be updated:
+    assert cs.calculate_hash() == "ec6042f45aedddb79fbe6245c32f2c4fcbf0b0674242a1bbf15d5a9a2b9c26bc"
+
+    # TBD: Better verification of results.
+    # For now we just exercise codepaths but with magicmock target they may supply almost anything
+    cas = mocker.MagicMock()
+    cs.restore_pre_data(cas)
+    cs.restore_post_data(cas)
+
+
+def test_schema_keyspace_iterate_user_types_in_restore_order(schema):
+    ut1 = schema.CassandraUserType(name="ut1", cql_create_self="", field_types=[])
+    ut2 = schema.CassandraUserType(name="ut2", cql_create_self="", field_types=["ut3", "map<str,frozen<ut1>>"])
+    ut3 = schema.CassandraUserType(name="ut3", cql_create_self="", field_types=["ut4"])
+    ut4 = schema.CassandraUserType(name="ut4", cql_create_self="", field_types=["something"])
+    ks = schema.CassandraKeyspace(
+        name="unused",
+        cql_create_all="unused",
+        cql_create_self="unused",
+        aggregates=[],
+        functions=[],
+        tables=[],
+        user_types=[ut1, ut2, ut3, ut4],
+    )
+    uts = list(ks.iterate_user_types_in_restore_order())
+    expected_uts = [ut1, ut4, ut3, ut2]
+    assert uts == expected_uts
+
+    # Ensure loop detection works
+    ut5 = schema.CassandraUserType(name="ut5", cql_create_self="", field_types=["ut5"])
+    ks.user_types = [ut5]
+    with pytest.raises(ValueError):
+        uts = list(ks.iterate_user_types_in_restore_order())
+        print(uts)  # unreachable unless there is a bug
+
+
+@pytest.mark.parametrize(
+    "definition,identifiers",
+    [
+        ("foo", ["foo"]),
+        ("map<frozen<foo>>", ["foo"]),
+        ('"q""u""o""t""e""d"', ['q"u"o"t"e"d']),
+    ],
+)
+def test_iterate_identifiers_in_cql_type_definition(schema, definition, identifiers):
+    got_identifiers = list(schema._iterate_identifiers_in_cql_type_definition(definition))
+    assert got_identifiers == identifiers

--- a/tests/unit/coordinator/plugins/cassandra/test_backup_steps.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_backup_steps.py
@@ -1,0 +1,89 @@
+"""
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+
+# pylint: disable=protected-access
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Optional
+from uuid import UUID
+
+import pytest
+
+
+@dataclass(frozen=True)
+class RetrieveTestCase:
+    name: str
+
+    # Input
+    field: Optional[str] = None
+    populate_rf: int = 2
+    populate_tokens: int = 7
+    populate_nodes: int = 3
+    # Erroneous input mode - give all nodes same address
+    duplicate_address: bool = False
+
+    # Output
+    expected_error: Optional[Exception] = None
+
+    def __str__(self):
+        return self.name
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        RetrieveTestCase(name="no matching nodes", field=None, expected_error=ValueError),
+        RetrieveTestCase(name="multiple matching nodes", field="address", duplicate_address=True, expected_error=ValueError),
+    ]
+    + [RetrieveTestCase(name=f"match by {field}", field=field) for field in ["address", "host_id", "listen_address"]],
+    ids=str,
+)
+def test_retrieve_manifest_from_cassandra(mocker, case):
+    backup_steps = pytest.importorskip("astacus.coordinator.plugins.cassandra.model.backup_steps")
+    plugin_model = pytest.importorskip("astacus.coordinator.plugins.cassandra.model")
+    cassandra_schema = pytest.importorskip("astacus.common.cassandra.schema")
+    mocker.patch.object(
+        cassandra_schema.CassandraSchema,
+        "from_cassandra_session",
+        return_value=cassandra_schema.CassandraSchema(keyspaces=[]),
+    )
+
+    cassandra_nodes = [
+        SimpleNamespace(
+            host_id=UUID(f"1234567812345678123456781234567{node}"),
+            address=f"1.2.3.{node}" if not case.duplicate_address else "127.0.0.1",
+            listen_address="la" if node == 0 else None,
+            broadcast_address=f"ba{node}" if node != 0 else None,
+            rack="unused",
+        )
+        for node in range(case.populate_nodes)
+    ]
+    token_to_host_owner_map_items = [
+        (SimpleNamespace(value=f"token{token}"), cassandra_nodes[node])
+        for node in range(case.populate_nodes)
+        for token in range(case.populate_tokens)
+        if ((node + node * token) // case.populate_rf) % case.populate_nodes == 0
+    ]
+
+    mocked_map = SimpleNamespace(items=mocker.Mock(return_value=token_to_host_owner_map_items))
+    cas = SimpleNamespace(cluster_metadata=SimpleNamespace(token_map=SimpleNamespace(token_to_host_owner=mocked_map)))
+
+    nodes = []
+    for cassandra_node in cassandra_nodes:
+        cnode = plugin_model.CassandraConfigurationNode()
+        # Note: 'tokens' is bit awkward to to test and unlikely to be really used so not tested here.
+        if case.field:
+            if case.field == "listen_address":
+                setattr(cnode, case.field, cassandra_node.listen_address or cassandra_node.broadcast_address)
+            else:
+                setattr(cnode, case.field, getattr(cassandra_node, case.field))
+        nodes.append(cnode)
+    if case.expected_error:
+        with pytest.raises(case.expected_error):
+            backup_steps._retrieve_manifest_from_cassandra(cas, nodes)
+        return
+    manifest = backup_steps._retrieve_manifest_from_cassandra(cas, nodes)
+    assert len(manifest.nodes) == len(nodes)

--- a/tests/unit/coordinator/plugins/cassandra/test_plugin.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_plugin.py
@@ -1,0 +1,55 @@
+"""
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+
+from astacus.common import ipc
+from astacus.coordinator.plugins.base import StepFailedError
+from tests.unit.node.test_node_cassandra import CassandraTestConfig
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(name="cplugin")
+def fixture_cplugin(mocker, tmpdir):
+    plugin = pytest.importorskip("astacus.coordinator.plugins.cassandra.plugin")
+    ctc = CassandraTestConfig(mocker=mocker, tmpdir=tmpdir)
+    yield plugin.CassandraPlugin(client=ctc.cassandra_client_config)
+
+
+async def test_step_cassandrasubop(mocker):
+    plugin = pytest.importorskip("astacus.coordinator.plugins.cassandra.plugin")
+    mocker.patch.object(plugin, "run_subop")
+
+    step = plugin.CassandraSubOpStep(op=ipc.CassandraSubOp.stop_cassandra)
+    cluster = None
+    context = None
+    result = await step.run_step(cluster, context)
+    assert result is None
+
+
+@pytest.mark.parametrize("success", [False, True])
+async def test_step_cassandra_validate_configuration(mocker, success):
+    plugin = pytest.importorskip("astacus.coordinator.plugins.cassandra.plugin")
+    step = plugin.ValidateConfigurationStep(nodes=[])
+    context = None
+    if success:
+        cluster = SimpleNamespace(nodes=[])
+        result = await step.run_step(cluster, context)
+        assert result is None
+    else:
+        # node count mismatch
+        cluster = SimpleNamespace(nodes=[42])
+        with pytest.raises(StepFailedError):
+            await step.run_step(cluster, context)
+
+
+def test_get_backup_steps(mocker, cplugin):
+    context = mocker.Mock()
+    cplugin.get_backup_steps(context=context)
+
+
+def test_get_restore_steps(mocker, cplugin):
+    context = mocker.Mock()
+    cplugin.get_restore_steps(context=context, req=ipc.RestoreRequest())

--- a/tests/unit/coordinator/plugins/cassandra/test_restore_steps.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_restore_steps.py
@@ -1,0 +1,97 @@
+"""
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+
+from astacus.common import ipc
+from astacus.coordinator.plugins import base
+from types import SimpleNamespace
+
+import datetime
+import pytest
+
+# TBD: Eventually multinode configuration would be perhaps interesting to test too
+
+
+async def test_step_start_cassandra(mocker):
+    restore_steps = pytest.importorskip("astacus.coordinator.plugins.cassandra.model.restore_steps")
+    cassandra_schema = pytest.importorskip("astacus.common.cassandra.schema")
+    plugin_model = pytest.importorskip("astacus.coordinator.plugins.cassandra.model")
+
+    schema = cassandra_schema.CassandraSchema(keyspaces=[])
+
+    plugin_manifest = plugin_model.CassandraManifest(
+        cassandra_schema=schema,
+        nodes=[
+            plugin_model.CassandraManifestNode(
+                address="127.0.0.1",
+                host_id="12345678123456781234567812345678",
+                listen_address="::1",
+                rack="unused",
+                tokens=["token0"],
+            )
+        ],
+    )
+
+    backup_manifest = ipc.BackupManifest(
+        start=datetime.datetime.now(),
+        attempt=1,
+        snapshot_results=[ipc.SnapshotResult()],
+        upload_results=[],
+        plugin=ipc.Plugin.cassandra,
+        plugin_data=plugin_manifest.dict(),
+    )
+
+    def get_result(cl):
+        if cl == base.BackupManifestStep:
+            return backup_manifest
+        if cl == restore_steps.ParsePluginManifestStep:
+            return plugin_manifest
+        raise NotImplementedError(cl)
+
+    mocker.patch.object(restore_steps, "run_subop")
+
+    step = restore_steps.StartCassandraStep(partial_restore_nodes=None)
+    context = SimpleNamespace(get_result=get_result)
+    cluster = SimpleNamespace(nodes=[SimpleNamespace(az="az1")])
+    result = await step.run_step(cluster, context)
+    assert result is None
+
+
+class AsyncIterableWrapper:
+    def __init__(self, iterable):
+        self.data = list(iterable)
+        self.index = -1
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        self.index += 1
+        if self.index >= len(self.data):
+            raise StopAsyncIteration
+        return self.data[self.index]
+
+
+@pytest.mark.parametrize("steps,success", [([True], True), ([False, True], True), ([False], False)])
+async def test_step_wait_cassandra_up(mocker, steps, success):
+    restore_steps = pytest.importorskip("astacus.coordinator.plugins.cassandra.model.restore_steps")
+    get_schema_steps = steps[:]
+
+    async def get_schema_hash(cluster):
+        assert get_schema_steps
+        return get_schema_steps.pop(0), "unused-error"
+
+    mocker.patch.object(restore_steps, "get_schema_hash", new=get_schema_hash)
+
+    mocker.patch.object(restore_steps.utils, "exponential_backoff", return_value=AsyncIterableWrapper(steps))
+
+    step = restore_steps.WaitCassandraUpStep(duration=123)
+    context = None
+    cluster = None
+    if success:
+        result = await step.run_step(cluster, context)
+        assert result is None
+    else:
+        with pytest.raises(base.StepFailedError):
+            await step.run_step(cluster, context)

--- a/tests/unit/coordinator/plugins/cassandra/test_utils.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_utils.py
@@ -1,0 +1,46 @@
+"""
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+
+from astacus.common import ipc
+from astacus.coordinator.plugins.base import StepFailedError
+from astacus.coordinator.plugins.cassandra import utils
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.parametrize("start_ok", [False, True])
+async def test_run_subop(mocker, start_ok):
+    async def request_from_nodes(*args, **kwargs):
+        if start_ok:
+            return 42
+        return
+
+    async def wait_successful_results(*, start_results, result_class):
+        assert start_results == 42
+        return 7
+
+    cluster = SimpleNamespace(request_from_nodes=request_from_nodes, wait_successful_results=wait_successful_results)
+    try:
+        result = await utils.run_subop(cluster=cluster, subop=ipc.CassandraSubOp.stop_cassandra, result_class=ipc.NodeResult)
+    except StepFailedError:
+        assert not start_ok
+        return
+    assert start_ok
+    assert result == 7
+
+
+@pytest.mark.parametrize(
+    "hashes,result",
+    [
+        ([], ("", "Unable to retrieve schema hash at all")),
+        ([1, 2], ("", "Multiple schema hashes present: [1, 2]")),
+        ([1], (1, "")),
+    ],
+)
+async def test_get_schema_hash(mocker, hashes, result):
+    mocker.patch.object(utils, "run_subop", return_value=[SimpleNamespace(schema_hash=hash) for hash in hashes])
+    actual_result = await utils.get_schema_hash(None)
+    assert actual_result == result

--- a/tests/unit/node/conftest.py
+++ b/tests/unit/node/conftest.py
@@ -32,6 +32,7 @@ def fixture_app(tmpdir):
     (root / "foobig2").write_text("foobar" * magic.EMBEDDED_FILE_SIZE)
     app.state.node_config = NodeConfig.parse_obj(
         {
+            "az": "testaz",
             "root": str(root),
             "object_storage": {
                 "temporary_directory": str(tmp_path),

--- a/tests/unit/node/test_node_cassandra.py
+++ b/tests/unit/node/test_node_cassandra.py
@@ -1,0 +1,140 @@
+"""
+Copyright (c) 2021 Aiven Ltd
+See LICENSE for details
+"""
+
+from astacus.common import ipc
+from astacus.common.cassandra.config import SNAPSHOT_NAME
+from astacus.node.config import CassandraNodeConfig
+from tests.unit.conftest import CassandraTestConfig
+
+import pytest
+import subprocess
+
+
+class CassandraTestEnv(CassandraTestConfig):
+    cassandra_node_config: CassandraNodeConfig
+
+    def __init__(self, *, app, client, mocker, tmpdir):
+        super().__init__(mocker=mocker, tmpdir=tmpdir)
+        self.app = app
+        self.client = client
+
+    def lock(self):
+        response = self.client.post("/node/lock?locker=x&ttl=10")
+        assert response.status_code == 200, response.json()
+
+    def post(self, *, subop, **kwargs):
+        url = f"/node/cassandra/{subop}"
+        return self.client.post(url, **kwargs)
+
+    def get_status(self, response):
+        assert response.status_code == 200, response.json()
+        status_url = response.json()["status_url"]
+        return self.client.get(status_url)
+
+    def setup_cassandra_node_config(self):
+        self.cassandra_node_config = CassandraNodeConfig(
+            client=self.cassandra_client_config,
+            nodetool_command=["nodetool"],
+            start_command=["dummy-start"],
+            stop_command=["dummy-stop"],
+        )
+        self.app.state.node_config.cassandra = self.cassandra_node_config
+
+
+@pytest.fixture(name="ctenv")
+def fixture_ctenv(app, client, mocker, tmpdir):
+    return CassandraTestEnv(app=app, client=client, mocker=mocker, tmpdir=tmpdir)
+
+
+@pytest.mark.parametrize("subop", ipc.CassandraSubOp)
+def test_api_cassandra_subop(app, ctenv, mocker, subop):
+    req_json = {"tokens": ["42", "7"]}
+
+    # Without lock, we shouldn't be able to do use the endpoint
+    response = ctenv.post(subop=subop, json=req_json)
+    if response.status_code == 501:
+        # If Cassandra module is missing, endpoint will return 501
+        return
+
+    assert response.status_code == 409, response.json()
+
+    ctenv.lock()
+
+    # No Cassandra configuration in node_config yet -> should fail
+    with pytest.raises(AssertionError):
+        response = ctenv.post(subop=subop, json=req_json)
+
+    ctenv.setup_cassandra_node_config()
+    subprocess_run = mocker.patch.object(subprocess, "run")
+
+    # Now the app is actually correctly configured
+
+    if subop == ipc.CassandraSubOp.get_schema_hash:
+        # This is tested separately
+        return
+
+    response = ctenv.post(subop=subop, json=req_json)
+
+    # Ensure that besides the measurable internal effect, the API also
+    # returns 200 for the status-url + the progress has completed.
+    status = ctenv.get_status(response)
+    assert status.status_code == 200, response.json()
+
+    progress = status.json()["progress"]
+    assert not progress["failed"]
+    assert progress["final"]
+
+    if subop == ipc.CassandraSubOp.remove_snapshot:
+        assert not ctenv.snapshot_path.exists()
+        assert ctenv.other_snapshot_path.exists()
+    elif subop == ipc.CassandraSubOp.restore_snapshot:
+        # The file should be moved from dummytable-123 snapshot dir to
+        # dummytable-234
+        assert (ctenv.root / "data" / "dummyks" / "dummytable-234" / "asdf").read_text() == "foobar"
+        assert progress["handled"]
+    elif subop == ipc.CassandraSubOp.start_cassandra:
+        subprocess_run.assert_any_call(ctenv.cassandra_node_config.start_command + ["tempfilename"], check=True)
+
+        assert (
+            ctenv.fake_conffile.getvalue()
+            == """auto_bootstrap: false
+initial_token: 42, 7
+listen_address: 127.0.0.1
+"""
+        )
+    elif subop == ipc.CassandraSubOp.stop_cassandra:
+        subprocess_run.assert_any_call(ctenv.cassandra_node_config.stop_command, check=True)
+    elif subop == ipc.CassandraSubOp.take_snapshot:
+        subprocess_run.assert_any_call(
+            ctenv.cassandra_node_config.nodetool_command + ["snapshot", "-t", SNAPSHOT_NAME], check=True
+        )
+    else:
+        raise NotImplementedError(subop)
+
+
+@pytest.mark.parametrize("fail", [True])
+def test_api_cassandra_get_schema_hash(ctenv, fail, mocker):
+    # The state of API *before* these two setup steps are done is checked in the test_api_cassandra_subop
+    ctenv.lock()
+    ctenv.setup_cassandra_node_config()
+
+    node_cassandra = pytest.importorskip("astacus.node.cassandra")
+
+    if not fail:
+        mocker.patch.object(node_cassandra.CassandraOp, "_get_schema_hash", return_value="mockhash")
+
+    response = ctenv.post(subop=ipc.CassandraSubOp.get_schema_hash, json={})
+    status = ctenv.get_status(response)
+    assert status.status_code == 200, response.json()
+
+    progress = status.json()["progress"]
+    assert not progress["failed"]
+    assert progress["final"]
+
+    schema_hash = status.json()["schema_hash"]
+    if fail:
+        assert not schema_hash
+    else:
+        assert schema_hash == "mockhash"

--- a/tests/unit/node/test_node_snapshot.py
+++ b/tests/unit/node/test_node_snapshot.py
@@ -113,6 +113,7 @@ def test_api_snapshot_and_upload(client, mocker):
     assert result.hashes
     assert result.files
     assert result.total_size
+    assert result.az
 
     # Ask it to be uploaded
     response = client.post("/node/upload")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -20,6 +20,8 @@ def test_config_sample_load(path, tmpdir):
 
     (astacus_dir / "src").mkdir()  # root
     (astacus_dir / "backup").mkdir()  # object storage
+
+    (astacus_dir / "cassandra").mkdir()  # cassandra data
     (astacus_dir / "m3").mkdir()  # m3 data
 
     app = FastAPI()


### PR DESCRIPTION
First draft of Cassandra plugin + some odds and ends.

This replaces https://github.com/aiven/astacus/pull/55 

Note: I changed the PR workflow to have two modes of running - minimal (base astacus) to ensure e.g. imports don't break for stuff not supported, and maximal (install whatever we can) for maximum coverage. Minimal is run only for one Python version as it is most likely not breaking differently in different Python versions, and maximal for all supported ones.

Also added codecov.io support for Astacus as I think we've chosen that as the service to use for OSS projects.