### PR TITLE
hot-reload of configuration through API and CLI client

### DIFF
--- a/astacus/client.py
+++ b/astacus/client.py
@@ -167,6 +167,20 @@ def _reload_config(args) -> bool:
     return response is not None
 
 
+def _check_reload_config(args) -> bool:
+    response = http_request(f"{args.url}/config/status", method="get", caller="client._check_reload_config")
+    if response is None:
+        print("Failed to get configuration status")
+        return False
+    if args.status:
+        return not response["needs_reload"]
+    if response["needs_reload"]:
+        print("Configuration needs to be reloaded")
+    else:
+        print("Configuration does not need to be reloaded")
+    return True
+
+
 def create_client_parsers(parser, subparsers):
     default_url = f"http://localhost:{magic.ASTACUS_DEFAULT_PORT}"
     parser.add_argument("-u", "--url", type=str, help="Astacus REST endpoint URL", default=default_url)
@@ -179,6 +193,14 @@ def create_client_parsers(parser, subparsers):
 
     p_reload = subparsers.add_parser("reload", help="Reload astacus configuration")
     p_reload.set_defaults(func=_reload_config)
+
+    p_check_reload = subparsers.add_parser(
+        "check-reload", help="Check if the astacus configuration needs to be reloaded from disk"
+    )
+    p_check_reload.set_defaults(func=_check_reload_config)
+    p_check_reload.add_argument(
+        "--status", action="store_true", help="Returns a status code of 1 if the configuration needs to be reloaded"
+    )
 
     p_backup = subparsers.add_parser("backup", help="Request backup")
     p_backup.set_defaults(func=_run_backup)

--- a/astacus/client.py
+++ b/astacus/client.py
@@ -162,6 +162,11 @@ def _run_delete(args) -> bool:
     return _run_op("cleanup", args, json={"explicit_delete": args.backups})
 
 
+def _reload_config(args) -> bool:
+    response = http_request(f"{args.url}/config/reload", method="post", caller="client._reload_config")
+    return response is not None
+
+
 def create_client_parsers(parser, subparsers):
     default_url = f"http://localhost:{magic.ASTACUS_DEFAULT_PORT}"
     parser.add_argument("-u", "--url", type=str, help="Astacus REST endpoint URL", default=default_url)
@@ -171,6 +176,9 @@ def create_client_parsers(parser, subparsers):
         type=int,
         help="Wait at most this long the requested (client) operation to complete (unit:seconds)",
     )
+
+    p_reload = subparsers.add_parser("reload", help="Reload astacus configuration")
+    p_reload.set_defaults(func=_reload_config)
 
     p_backup = subparsers.add_parser("backup", help="Request backup")
     p_backup.set_defaults(func=_run_backup)

--- a/astacus/coordinator/api.py
+++ b/astacus/coordinator/api.py
@@ -102,13 +102,15 @@ async def _list_backups(*, req: ipc.ListRequest = ipc.ListRequest(), c: Coordina
     if c.state.cached_list_running:
         raise HTTPException(status_code=429, detail="Already caching list result")
     c.state.cached_list_running = True
-    list_response = await to_thread(list_backups, req=req, json_mstorage=c.json_mstorage)
-    c.state.cached_list_response = CachedListResponse(
-        coordinator_config=coordinator_config,
-        list_request=req,
-        list_response=list_response,
-    )
-    c.state.cached_list_running = False
+    try:
+        list_response = await to_thread(list_backups, req=req, json_mstorage=c.json_mstorage)
+        c.state.cached_list_response = CachedListResponse(
+            coordinator_config=coordinator_config,
+            list_request=req,
+            list_response=list_response,
+        )
+    finally:
+        c.state.cached_list_running = False
     return list_response
 
 

--- a/astacus/coordinator/state.py
+++ b/astacus/coordinator/state.py
@@ -11,6 +11,7 @@ By design it cannot be persisted to disk, but e.g. op_info can be if necessary.
 
 from astacus.common import ipc, utils
 from astacus.common.op import OpState
+from astacus.coordinator.config import CoordinatorConfig
 from dataclasses import dataclass
 from fastapi import FastAPI, Request
 from pydantic import Field
@@ -23,6 +24,7 @@ APP_KEY = "coordinator_state"
 
 class CachedListResponse(utils.AstacusModel):
     timestamp: float = Field(default_factory=time.monotonic)
+    coordinator_config: CoordinatorConfig
     list_request: ipc.ListRequest
     list_response: ipc.ListResponse
 

--- a/astacus/server.py
+++ b/astacus/server.py
@@ -78,7 +78,7 @@ def _systemd_notify_ready():
         subprocess.run(["systemd-notify", "--ready"], check=True)
 
 
-def _run_server(args):
+def _run_server(args) -> bool:
     # On reload (and following init_app), the app is configured based on this
     os.environ["ASTACUS_CONFIG"] = args.config
     uconfig = init_app().state.global_config.uvicorn
@@ -131,6 +131,7 @@ def _run_server(args):
         },
         http=uconfig.http,
     )
+    return True
 
 
 def create_server_parser(subparsers):

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -137,9 +137,10 @@ async def _astacus(*, tmpdir, rootdir, index):
     # cmd = ["astacus", "server", "-c", str(a_conf_path)]
     cmd = [sys.executable, "-m", "astacus.main", "server", "-c", str(a_conf_path)]
 
-    async with background_process(*cmd, env={"PYTHONPATH": astacus_source_root}):
+    async with background_process(*cmd, env={"PYTHONPATH": astacus_source_root}) as process:
         await wait_url_up(node.url)
         yield node
+    assert process.returncode == 0
 
 
 @pytest.fixture(name="astacus1")

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -171,14 +171,20 @@ async def fixture_astacus3(tmpdir):
         yield a
 
 
-def astacus_run(rootdir: str, astacus: TestNode, *args: str) -> None:
+def astacus_run(
+    rootdir: str,
+    astacus: TestNode,
+    *args: str,
+    check: bool = True,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess:
     # simulate this (for some reason, in podman the 'astacus' command
     # is not to be found, I suppose the package hasn't been
     # initialized)
     #
     # cmd = ["astacus", "--url", astacus.url, "-w", "10"]
     cmd = [sys.executable, "-m", "astacus.main", "--url", astacus.url, "-w", "10"]
-    subprocess.run(cmd + list(args), check=True, env={"PYTHONPATH": rootdir})
+    return subprocess.run(cmd + list(args), check=check, capture_output=capture_output, env={"PYTHONPATH": rootdir})
 
 
 def astacus_ls(astacus: TestNode) -> List[str]:

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class TestNode(AstacusModel):
+    __test__ = False
     name: str
     url: str
     port: int

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -7,7 +7,8 @@ from contextlib import asynccontextmanager
 from httpx import URL
 from pathlib import Path
 from tests.utils import create_rohmu_config
-from typing import AsyncIterator, Optional, Union
+from types import MappingProxyType
+from typing import Any, AsyncIterator, List, Mapping, Optional, Union
 
 import asyncio
 import httpx
@@ -15,6 +16,7 @@ import json
 import logging
 import os.path
 import pytest
+import subprocess
 import sys
 
 logger = logging.getLogger(__name__)
@@ -37,6 +39,10 @@ ASTACUS_NODES = [
     TestNode(name="a2", url="http://localhost:55151", port=55151),
     TestNode(name="a3", url="http://localhost:55152", port=55152),
 ]
+
+DEFAULT_PLUGIN_CONFIG = {
+    "root_globs": ["*"],
+}
 
 
 @asynccontextmanager
@@ -70,16 +76,12 @@ async def background_process(
                         break
 
 
-def create_astacus_config_dict(*, tmpdir, root_path, link_path, node):
+def create_astacus_config_dict(
+    *, tmpdir: Path, root_path: Path, link_path: Path, node: TestNode, plugin_config: Mapping[str, Any]
+) -> Mapping[str, Any]:
     nodes = [{"url": f"{node.url}/node"} for node in ASTACUS_NODES]
     return {
-        "coordinator": {
-            "nodes": nodes,
-            "plugin": "files",
-            "plugin_config": {
-                "root_globs": ["*"],
-            },
-        },
+        "coordinator": {"nodes": nodes, "plugin": "files", "plugin_config": dict(plugin_config)},
         "node": {
             "root": str(root_path),
             "root_link": str(link_path),
@@ -92,15 +94,22 @@ def create_astacus_config_dict(*, tmpdir, root_path, link_path, node):
     }
 
 
-def create_astacus_config(*, tmpdir, node):
+def create_astacus_config(
+    *,
+    tmpdir,
+    node: TestNode,
+    plugin_config: Mapping[str, Any] = MappingProxyType(DEFAULT_PLUGIN_CONFIG),
+) -> Path:
     a = Path(tmpdir / "node" / node.name)
     node.path = a
     root_path = a / "root"
-    root_path.mkdir(parents=True)
+    root_path.mkdir(parents=True, exist_ok=True)
     node.root_path = root_path
     link_path = a / "link"
-    link_path.mkdir()
-    a_conf = create_astacus_config_dict(tmpdir=tmpdir, root_path=root_path, link_path=link_path, node=node)
+    link_path.mkdir(exist_ok=True)
+    a_conf = create_astacus_config_dict(
+        tmpdir=Path(tmpdir), root_path=root_path, link_path=link_path, node=node, plugin_config=plugin_config
+    )
     a_conf_path = a / "astacus.conf"
     a_conf_path.write_text(json.dumps(a_conf))
     return a_conf_path
@@ -126,7 +135,7 @@ def fixture_rootdir(pytestconfig):
 
 
 @asynccontextmanager
-async def _astacus(*, tmpdir, rootdir, index):
+async def _astacus(*, tmpdir, index):
     node = ASTACUS_NODES[index]
     a_conf_path = create_astacus_config(tmpdir=tmpdir, node=node)
     astacus_source_root = os.path.join(os.path.dirname(__file__), "..", "..")
@@ -145,18 +154,32 @@ async def _astacus(*, tmpdir, rootdir, index):
 
 
 @pytest.fixture(name="astacus1")
-async def fixture_astacus1(tmpdir, rootdir):
-    async with _astacus(tmpdir=tmpdir, rootdir=rootdir, index=0) as a:
+async def fixture_astacus1(tmpdir):
+    async with _astacus(tmpdir=tmpdir, index=0) as a:
         yield a
 
 
 @pytest.fixture(name="astacus2")
-async def fixture_astacus2(tmpdir, rootdir):
-    async with _astacus(tmpdir=tmpdir, rootdir=rootdir, index=1) as a:
+async def fixture_astacus2(tmpdir):
+    async with _astacus(tmpdir=tmpdir, index=1) as a:
         yield a
 
 
 @pytest.fixture(name="astacus3")
-async def fixture_astacus3(tmpdir, rootdir):
-    async with _astacus(tmpdir=tmpdir, rootdir=rootdir, index=2) as a:
+async def fixture_astacus3(tmpdir):
+    async with _astacus(tmpdir=tmpdir, index=2) as a:
         yield a
+
+
+def astacus_run(rootdir: str, astacus: TestNode, *args: str) -> None:
+    # simulate this (for some reason, in podman the 'astacus' command
+    # is not to be found, I suppose the package hasn't been
+    # initialized)
+    #
+    # cmd = ["astacus", "--url", astacus.url, "-w", "10"]
+    cmd = [sys.executable, "-m", "astacus.main", "--url", astacus.url, "-w", "10"]
+    subprocess.run(cmd + list(args), check=True, env={"PYTHONPATH": rootdir})
+
+
+def astacus_ls(astacus: TestNode) -> List[str]:
+    return sorted(str(x.relative_to(astacus.root_path)) for x in astacus.root_path.glob("**/*"))

--- a/tests/system/test_astacus.py
+++ b/tests/system/test_astacus.py
@@ -7,18 +7,13 @@ Basic backup-restore cycle and its variations
 """
 
 from astacus.common import magic
+from tests.system.conftest import astacus_ls, astacus_run
 
 import logging
 import pytest
 import shutil
-import subprocess
-import sys
 
 logger = logging.getLogger(__name__)
-
-
-def _astacus_ls(astacus):
-    return sorted(str(x.relative_to(astacus.root_path)) for x in astacus.root_path.glob("**/*"))
 
 
 A1_FILES_AND_CONTENTS = [
@@ -34,15 +29,6 @@ A1_FILES_AND_CONTENTS = [
 @pytest.mark.order("last")
 @pytest.mark.asyncio
 async def test_astacus(astacus1, astacus2, astacus3, rootdir):
-    def astacus_run(astacus, *args):
-        # simulate this (for some reason, in podman the 'astacus' command
-        # is not to be found, I suppose the package hasn't been
-        # initialized)
-        #
-        # cmd = ["astacus", "--url", astacus.url, "-w", "10"]
-        cmd = [sys.executable, "-m", "astacus.main", "--url", astacus.url, "-w", "10"]
-        subprocess.run(cmd + list(args), check=True, env={"PYTHONPATH": rootdir})
-
     # Idea:
     # Store following files
     # a1 - A1_FILES_AND_CONTENTS
@@ -53,7 +39,7 @@ async def test_astacus(astacus1, astacus2, astacus3, rootdir):
     file1_2_path = astacus2.root_path / "file1"
     file1_2_path.write_text("content1")
 
-    astacus_run(astacus1, "backup")
+    astacus_run(rootdir, astacus1, "backup")
 
     # Clear node 1, add file that did not exist at time of backup
     shutil.rmtree(astacus1.root_path)
@@ -62,13 +48,13 @@ async def test_astacus(astacus1, astacus2, astacus3, rootdir):
     file3_path.write_text("content3")
 
     # Ensure 'list' command does not crash (output validation is bit too painful)
-    astacus_run(astacus1, "list")
+    astacus_run(rootdir, astacus1, "list")
 
-    astacus_run(astacus1, "cleanup", "--minimum-backups", "7", "--maximum-backups", "42", "--keep-days", "15")
-    astacus_run(astacus1, "delete", "--backups", "nonexistent-is-ok")
+    astacus_run(rootdir, astacus1, "cleanup", "--minimum-backups", "7", "--maximum-backups", "42", "--keep-days", "15")
+    astacus_run(rootdir, astacus1, "delete", "--backups", "nonexistent-is-ok")
 
     # Run restore
-    astacus_run(astacus2, "restore")
+    astacus_run(rootdir, astacus2, "restore")
 
     # Should have now:
     # a1 - A1_FILES_AND_CONTENTS
@@ -77,6 +63,6 @@ async def test_astacus(astacus1, astacus2, astacus3, rootdir):
     for name, content in A1_FILES_AND_CONTENTS:
         assert (astacus1.root_path / name).read_text() == content
     assert file1_2_path.read_text() == "content1"
-    assert _astacus_ls(astacus1) == sorted(x[0] for x in A1_FILES_AND_CONTENTS)
-    assert _astacus_ls(astacus2) == ["file1"]
-    assert _astacus_ls(astacus3) == []
+    assert astacus_ls(astacus1) == sorted(x[0] for x in A1_FILES_AND_CONTENTS)
+    assert astacus_ls(astacus2) == ["file1"]
+    assert astacus_ls(astacus3) == []

--- a/tests/system/test_config_reload.py
+++ b/tests/system/test_config_reload.py
@@ -15,7 +15,18 @@ import pytest
 def test_reload_config(tmpdir, rootdir: str, astacus1: TestNode, astacus2: TestNode, astacus3: TestNode) -> None:
     # Update the root_globs config of the first node
     create_astacus_config(tmpdir=tmpdir, node=astacus1, plugin_config={"root_globs": ["*.foo"]})
+    # Check that astacus can detect that reloading config is needed
+    assert astacus_run(rootdir, astacus1, "check-reload", "--status", check=False).returncode == 1
+    check_without_status = astacus_run(rootdir, astacus1, "check-reload", check=True, capture_output=True)
+    assert check_without_status.returncode == 0
+    assert "Configuration needs to be reloaded" in check_without_status.stdout.decode()
+    # Reload
     astacus_run(rootdir, astacus1, "reload")
+    # And now reload isn't needed anymore
+    assert astacus_run(rootdir, astacus1, "check-reload", check=False).returncode == 0
+    check_without_status = astacus_run(rootdir, astacus1, "check-reload", check=True, capture_output=True)
+    assert check_without_status.returncode == 0
+    assert "Configuration does not need to be reloaded" in check_without_status.stdout.decode()
     # Write some data to backup, including files that don't match the reloaded glob
     (astacus1.root_path / "saved.foo").write_text("dont_care")
     (astacus1.root_path / "ignored.bar").write_text("dont_care")

--- a/tests/system/test_config_reload.py
+++ b/tests/system/test_config_reload.py
@@ -1,0 +1,29 @@
+"""
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+
+Hot-reloading of astacus configuration
+"""
+
+from tests.system.conftest import astacus_ls, astacus_run, create_astacus_config, TestNode
+
+import pytest
+
+
+@pytest.mark.order("last")
+@pytest.mark.asyncio
+def test_reload_config(tmpdir, rootdir: str, astacus1: TestNode, astacus2: TestNode, astacus3: TestNode) -> None:
+    # Update the root_globs config of the first node
+    create_astacus_config(tmpdir=tmpdir, node=astacus1, plugin_config={"root_globs": ["*.foo"]})
+    astacus_run(rootdir, astacus1, "reload")
+    # Write some data to backup, including files that don't match the reloaded glob
+    (astacus1.root_path / "saved.foo").write_text("dont_care")
+    (astacus1.root_path / "ignored.bar").write_text("dont_care")
+    # Backup
+    astacus_run(rootdir, astacus1, "backup")
+    # Remove all files
+    (astacus1.root_path / "saved.foo").unlink()
+    (astacus1.root_path / "ignored.bar").unlink()
+    # Restore and confirm that only the files matching the reloaded glob are present
+    astacus_run(rootdir, astacus1, "restore")
+    assert astacus_ls(astacus1) == ["saved.foo"]

--- a/tests/unit/common/test_op_stats.py
+++ b/tests/unit/common/test_op_stats.py
@@ -20,7 +20,6 @@ from starlette.datastructures import URL
 from unittest.mock import patch
 
 import pytest
-import threading
 
 
 class DummyStep(Step[bool]):
@@ -49,7 +48,6 @@ async def test_op_stats():
         config=CoordinatorConfig(plugin=Plugin.files),
         state=CoordinatorState(),
         stats=stats,
-        sync_lock=threading.RLock(),
         hexdigest_mstorage=MultiStorage(),
         json_mstorage=MultiStorage(),
     )

--- a/tests/unit/coordinator/plugins/test_m3db.py
+++ b/tests/unit/coordinator/plugins/test_m3db.py
@@ -33,7 +33,6 @@ from typing import List, Optional
 
 import pytest
 import respx
-import threading
 
 ENV = "dummyenv"
 
@@ -81,7 +80,6 @@ def fixture_coordinator() -> Coordinator:
         config=CoordinatorConfig.parse_obj(COORDINATOR_CONFIG),
         state=CoordinatorState(),
         stats=StatsClient(config=None),
-        sync_lock=threading.RLock(),
         hexdigest_mstorage=MultiStorage(),
         json_mstorage=MultiStorage(),
     )


### PR DESCRIPTION
This allows updating the configuration without restarting astacus and interrupting the service.

Compared to a full restart, this removes the risk of long or leaked asyncio tasks not letting astacus restart quickly.

The reload "signal" uses an API endpoint instead of a `SIGHUP` because we can wait for its completion.
This makes it more reliable [when used with systemd](https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecReload=), or when we want to make sure a backup started
after the restart signal is really using the new configuration.

In the same spirit, an extra endpoint can tell whether the configuration needs to be reloaded.
This enables closed loop control of astacus and makes it possible to reliably run with the new configuration
even if the system in charge of reloading astacus temporarily fails or loses its state.

The configuration status endpoint shows only the hash of the loaded configuration.
This allows comparison with a know configuration file without leaking the entire configuration through the API,
which would be problematic since it contains secrets.