### PR TITLE
Fix Kazoo timeout during tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -133,7 +133,7 @@ def get_kazoo_host(zookeeper: Service) -> str:
 
 @pytest.fixture(name="zookeeper_client")
 def fixture_zookeeper_client(zookeeper: Service) -> KazooZooKeeperClient:
-    return KazooZooKeeperClient(hosts=[get_kazoo_host(zookeeper)], timeout=1)
+    return KazooZooKeeperClient(hosts=[get_kazoo_host(zookeeper)], timeout=10)
 
 
 @contextlib.asynccontextmanager


### PR DESCRIPTION
The timeout was only 1s and leading to flaky tests, increased it to 10s.