### PR TITLE
clickhouse: distribute parts according to shards

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,6 +12,7 @@ disable=
     no-member,                     # broken with pydantic + inheritance
     no-self-use,                   # annoying when fullfilling some API
     too-few-public-methods,        # some pydantic models have 0 and it is fine
+    too-many-arguments,
     too-many-instance-attributes,  # give me a break, <= 7
     too-many-locals,               # locals make the code more readable
     unused-argument,               # annoying when fullfilling some API

--- a/astacus/coordinator/plugins/clickhouse/plugin.py
+++ b/astacus/coordinator/plugins/clickhouse/plugin.py
@@ -17,6 +17,7 @@ from .steps import (
     RestoreReplicatedDatabasesStep,
     RetrieveAccessEntitiesStep,
     RetrieveDatabasesAndTablesStep,
+    RetrieveMacrosStep,
     SyncDatabaseReplicasStep,
     SyncTableReplicasStep,
     UnfreezeTablesStep,
@@ -100,7 +101,8 @@ class ClickHousePlugin(CoordinatorPlugin):
             BackupNameStep(json_storage=context.json_storage, requested_name=req.name),
             BackupManifestStep(json_storage=context.json_storage),
             ClickHouseManifestStep(),
-            ListDatabaseReplicasStep(clients=clients),
+            RetrieveMacrosStep(clients=clients),
+            ListDatabaseReplicasStep(),
             RestoreReplicatedDatabasesStep(
                 clients=clients,
                 replicated_databases_zookeeper_path=self.replicated_databases_zookeeper_path,

--- a/astacus/coordinator/plugins/clickhouse/plugin.py
+++ b/astacus/coordinator/plugins/clickhouse/plugin.py
@@ -66,6 +66,7 @@ class ClickHousePlugin(CoordinatorPlugin):
                 access_entities_path=self.replicated_access_zookeeper_path,
             ),
             RetrieveDatabasesAndTablesStep(clients=clickhouse_clients),
+            RetrieveMacrosStep(clients=clickhouse_clients),
             # Then freeze all tables
             FreezeTablesStep(clients=clickhouse_clients, freeze_name=self.freeze_name),
             # Then snapshot and backup all frozen table parts
@@ -113,8 +114,6 @@ class ClickHousePlugin(CoordinatorPlugin):
                 replicated_databases_zookeeper_path=self.replicated_databases_zookeeper_path,
                 sync_timeout=self.sync_databases_timeout,
             ),
-            # We should deduplicate parts of ReplicatedMergeTree tables to only download once from
-            # backup storage and then let ClickHouse replicate between all servers.
             RestoreStep(storage_name=context.storage_name, partial_restore_nodes=req.partial_restore_nodes),
             AttachMergeTreePartsStep(
                 clients=clients,

--- a/astacus/coordinator/plugins/clickhouse/steps.py
+++ b/astacus/coordinator/plugins/clickhouse/steps.py
@@ -8,14 +8,14 @@ from .dependencies import access_entities_sorted_by_dependencies, tables_sorted_
 from .escaping import escape_for_file_name, unescape_from_file_name
 from .macros import fetch_server_macros, Macros
 from .manifest import AccessEntity, ClickHouseManifest, ReplicatedDatabase, Table
-from .parts import (
-    check_parts_replication,
-    distribute_parts_to_servers,
-    get_frozen_parts_pattern,
-    group_files_into_parts,
-    list_parts_to_attach,
+from .parts import distribute_parts_to_servers, get_frozen_parts_pattern, group_files_into_parts, list_parts_to_attach
+from .replication import (
+    DatabaseReplica,
+    get_databases_replicas,
+    get_shard_and_replica,
+    get_tables_replicas,
+    sync_replicated_database,
 )
-from .replication import DatabaseReplica, get_shard_and_replica, sync_replicated_database
 from astacus.common import ipc
 from astacus.common.exceptions import TransientException
 from astacus.common.limiter import Limiter
@@ -349,11 +349,11 @@ class DistributeReplicatedPartsStep(Step[None]):
     Distribute replicated parts of table using the Replicated family of table engines.
 
     To avoid duplicating data during restoration, we must attach each replicated part
-    to only on one server and let the replication do its work.
+    to only on one server of each shard and let the replication do its work.
 
     This also serve as a performance and cost optimisation. Instead of fetching
     the same part from backup storage once for each server, we can fetch it only
-    once for the entire cluster and then let the cluster exchange parts internally.
+    once for each shard and then let the cluster exchange parts internally.
 
     This step must be run after `MoveFrozenPartsStep` to find the correct paths
     in the snapshot.
@@ -364,10 +364,12 @@ class DistributeReplicatedPartsStep(Step[None]):
         snapshot_files = [
             snapshot_result.state.files for snapshot_result in snapshot_results if snapshot_result.state is not None
         ]
-        _, tables = context.get_result(RetrieveDatabasesAndTablesStep)
-        table_uuids = {table.uuid for table in tables if table.is_replicated}
-        parts, server_files = group_files_into_parts(snapshot_files, table_uuids)
-        check_parts_replication(parts)
+        replicated_databases, tables = context.get_result(RetrieveDatabasesAndTablesStep)
+        replicated_tables = [table for table in tables if table.is_replicated]
+        server_macros = context.get_result(RetrieveMacrosStep)
+        databases_replicas = get_databases_replicas(replicated_databases, server_macros)
+        tables_replicas = get_tables_replicas(replicated_tables, databases_replicas)
+        parts, server_files = group_files_into_parts(snapshot_files, tables_replicas)
         distribute_parts_to_servers(parts, server_files)
         for files, snapshot_result in zip(server_files, snapshot_results):
             assert snapshot_result.state is not None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -158,6 +158,6 @@ log4j.appender.default.layout.ConversionPattern=[%-5p] %m%n
         if command is None:
             pytest.skip("zookeeper installation not found")
         async with run_process_and_wait_for_pattern(
-            args=command, cwd=data_dir, pattern="PrepRequestProcessor (sid:0) started"
+            args=command, cwd=data_dir, pattern="PrepRequestProcessor (sid:0) started", timeout=20.0
         ) as process:
             yield Service(process=process, port=port, data_dir=data_dir)

--- a/tests/integration/coordinator/plugins/clickhouse/test_replication.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_replication.py
@@ -17,7 +17,7 @@ pytestmark = [
 @pytest.mark.asyncio
 async def test_get_shard_and_replica(ports: Ports) -> None:
     async with create_zookeeper(ports) as zookeeper:
-        async with create_clickhouse_cluster(zookeeper, ports, cluster_size=1) as clickhouse_cluster:
+        async with create_clickhouse_cluster(zookeeper, ports, cluster_shards=["s1"]) as clickhouse_cluster:
             clickhouse = clickhouse_cluster.services[0]
             client = get_clickhouse_client(clickhouse)
             await client.execute(

--- a/tests/integration/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_steps.py
@@ -24,7 +24,7 @@ pytestmark = [
 async def test_retrieve_tables(ports: Ports) -> None:
     async with create_zookeeper(ports) as zookeeper:
         # We need a "real" cluster to be able to use Replicated databases
-        async with create_clickhouse_cluster(zookeeper, ports, cluster_size=1) as clickhouse_cluster:
+        async with create_clickhouse_cluster(zookeeper, ports, cluster_shards=["s1"]) as clickhouse_cluster:
             clickhouse = clickhouse_cluster.services[0]
             client = get_clickhouse_client(clickhouse)
             await client.execute(

--- a/tests/unit/coordinator/plugins/clickhouse/test_parts.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_parts.py
@@ -6,17 +6,18 @@ from astacus.common.ipc import SnapshotFile, SnapshotResult, SnapshotState
 from astacus.coordinator.plugins.clickhouse.manifest import Table
 from astacus.coordinator.plugins.clickhouse.parts import (
     add_file_to_parts,
-    check_parts_replication,
     distribute_parts_to_servers,
     get_frozen_parts_pattern,
+    get_part_servers,
     group_files_into_parts,
     list_parts_to_attach,
     Part,
     PartFile,
     PartKey,
 )
+from astacus.coordinator.plugins.clickhouse.replication import DatabaseReplica
 from pathlib import Path
-from typing import Dict, List
+from typing import List
 from uuid import UUID
 
 import copy
@@ -39,10 +40,13 @@ def create_part_files(*, table_uuid: UUID, part_name: str, digest_seed: str) -> 
     ]
 
 
-def create_part_from_part_files(part_files: List[SnapshotFile]) -> Part:
+def create_part_from_part_files(snapshot_files: List[SnapshotFile]) -> Part:
     return Part(
-        files={file.relative_path: PartFile(snapshot_file=file, servers={0, 1}) for file in part_files},
-        total_size=sum(file.file_size for file in part_files),
+        table_uuid=T1_UUID,
+        part_name="all_0_0_0",
+        servers={0, 1},
+        snapshot_files=snapshot_files,
+        total_size=sum(snapshot_file.file_size for snapshot_file in snapshot_files),
     )
 
 
@@ -52,18 +56,60 @@ TABLE_1_PART_2 = create_part_files(table_uuid=T1_UUID, part_name="all_1_1_0", di
 TABLE_1_PART_3 = create_part_files(table_uuid=T1_UUID, part_name="all_2_2_0", digest_seed="same")
 TABLE_3_PART_1A = create_part_files(table_uuid=T3_UUID, part_name="all_0_0_0", digest_seed="one")
 TABLE_3_PART_1B = create_part_files(table_uuid=T3_UUID, part_name="all_0_0_0", digest_seed="other")
+DATABASES_REPLICAS = [
+    DatabaseReplica(shard_name="shard_1", replica_name="node_1"),
+    DatabaseReplica(shard_name="shard_1", replica_name="node_2"),
+]
+SHARDED_DATABASE_REPLICAS = [
+    DatabaseReplica(shard_name="shard_1", replica_name="node_1"),
+    DatabaseReplica(shard_name="shard_2", replica_name="node_2"),
+]
 
 
 def test_group_files_into_parts_collects_parts_from_selected_tables() -> None:
     first_server_files = copy.deepcopy([*TABLE_1_PART_1, *TABLE_1_PART_2, *TABLE_1_PART_3])
     second_server_files = copy.deepcopy([*TABLE_1_PART_1, *TABLE_1_PART_2, *TABLE_1_PART_3])
-    parts, other_files = group_files_into_parts([first_server_files, second_server_files], {T1_UUID, T2_UUID})
+    tables_replicas = {T1_UUID: DATABASES_REPLICAS, T2_UUID: DATABASES_REPLICAS}
+    parts, other_files = group_files_into_parts([first_server_files, second_server_files], tables_replicas)
     assert len(parts) == 3
     for part, original_files in zip(parts, [TABLE_1_PART_1, TABLE_1_PART_2, TABLE_1_PART_3]):
-        assert sorted(part.files.keys()) == sorted([original_file.relative_path for original_file in original_files])
-        for file_path, file in part.files.items():
-            assert file_path == file.snapshot_file.relative_path
-            assert file.servers == {0, 1}
+        assert part.snapshot_files == original_files
+        assert part.total_size == 1120
+        assert part.servers == {0, 1}
+    assert other_files[0] == []
+    assert other_files[1] == []
+
+
+def test_group_files_into_parts_does_not_merge_unreplicated_parts_within_shard() -> None:
+    first_server_files = copy.deepcopy(TABLE_1_PART_1)
+    second_server_files = copy.deepcopy(TABLE_1_PART_2)
+    tables_replicas = {T1_UUID: DATABASES_REPLICAS, T2_UUID: DATABASES_REPLICAS}
+    parts, other_files = group_files_into_parts([first_server_files, second_server_files], tables_replicas)
+    server_1_parts = [part for part in parts if part.servers == {0}]
+    server_2_parts = [part for part in parts if part.servers == {1}]
+    assert len(server_1_parts) == 1
+    assert server_1_parts[0].snapshot_files == TABLE_1_PART_1
+    assert len(server_2_parts) == 1
+    assert server_2_parts[0].snapshot_files == TABLE_1_PART_2
+    assert other_files == [[], []]
+
+
+def test_group_files_into_parts_does_not_merge_parts_across_shards() -> None:
+    first_server_files = copy.deepcopy([*TABLE_1_PART_1, *TABLE_1_PART_2, *TABLE_1_PART_3])
+    second_server_files = copy.deepcopy([*TABLE_1_PART_1, *TABLE_1_PART_2, *TABLE_1_PART_3])
+    tables_replicas = {T1_UUID: SHARDED_DATABASE_REPLICAS, T2_UUID: SHARDED_DATABASE_REPLICAS}
+    parts, other_files = group_files_into_parts([first_server_files, second_server_files], tables_replicas)
+    # Because each server is in a different shard, despite having the same data
+    # we have twice as many part as the test where all servers were in the
+    # same shard.
+    server_1_parts = [part for part in parts if part.servers == {0}]
+    server_2_parts = [part for part in parts if part.servers == {1}]
+    assert len(server_1_parts) == 3
+    assert len(server_2_parts) == 3
+    for part, original_files in zip(server_1_parts, [TABLE_1_PART_1, TABLE_1_PART_2, TABLE_1_PART_3]):
+        assert part.snapshot_files == original_files
+    for part, original_files in zip(server_2_parts, [TABLE_1_PART_1, TABLE_1_PART_2, TABLE_1_PART_3]):
+        assert part.snapshot_files == original_files
     assert other_files[0] == []
     assert other_files[1] == []
 
@@ -71,7 +117,8 @@ def test_group_files_into_parts_collects_parts_from_selected_tables() -> None:
 def test_group_files_into_parts_ignores_parts_from_unselected_tables() -> None:
     first_server_files = copy.deepcopy([*TABLE_3_PART_1A])
     second_server_files = copy.deepcopy([*TABLE_3_PART_1B])
-    parts, other_files = group_files_into_parts([first_server_files, second_server_files], {T1_UUID, T2_UUID})
+    tables_replicas = {T1_UUID: DATABASES_REPLICAS, T2_UUID: DATABASES_REPLICAS}
+    parts, other_files = group_files_into_parts([first_server_files, second_server_files], tables_replicas)
     assert parts == []
     assert other_files[0] == TABLE_3_PART_1A
     assert other_files[1] == TABLE_3_PART_1B
@@ -80,7 +127,8 @@ def test_group_files_into_parts_ignores_parts_from_unselected_tables() -> None:
 def test_group_files_into_parts_ignores_unknown_files() -> None:
     first_server_files = [SnapshotFile(relative_path=Path("something/random_a"), file_size=100, mtime_ns=0)]
     second_server_files = [SnapshotFile(relative_path=Path("something/random_B"), file_size=100, mtime_ns=0)]
-    parts, other_files = group_files_into_parts([first_server_files, second_server_files], {T1_UUID, T2_UUID})
+    tables_replicas = {T1_UUID: DATABASES_REPLICAS, T2_UUID: DATABASES_REPLICAS}
+    parts, other_files = group_files_into_parts([first_server_files, second_server_files], tables_replicas)
     assert parts == []
     assert other_files[0] == first_server_files
     assert other_files[1] == second_server_files
@@ -101,10 +149,13 @@ def test_group_files_into_parts_ignores_unknown_files() -> None:
 )
 def test_add_file_to_parts_ignores_unknown_files(file_path: Path) -> None:
     snapshot_file = SnapshotFile(relative_path=file_path, file_size=100, mtime_ns=0)
-    parts: Dict[PartKey, Part] = {}
-    added = add_file_to_parts(snapshot_file=snapshot_file, server_index=0, table_uuids={T1_UUID}, parts=parts)
+    parts_files = {}
+    tables_replicas = {T1_UUID: [DatabaseReplica(shard_name="shard_1", replica_name="node_1")]}
+    added = add_file_to_parts(
+        snapshot_file=snapshot_file, server_index=0, tables_replicas=tables_replicas, parts_files=parts_files
+    )
     assert added is False
-    assert len(parts) == 0
+    assert len(parts_files) == 0
 
 
 def test_add_file_to_parts_adds_file() -> None:
@@ -114,11 +165,12 @@ def test_add_file_to_parts_adds_file() -> None:
         mtime_ns=0,
         hexdigest="0001",
     )
-    parts = {}
-    added = add_file_to_parts(snapshot_file=file_a, server_index=0, table_uuids={T1_UUID}, parts=parts)
+    parts_files = {}
+    tables_replicas = {T1_UUID: [DatabaseReplica(shard_name="shard_1", replica_name="node_1")]}
+    added = add_file_to_parts(snapshot_file=file_a, server_index=0, tables_replicas=tables_replicas, parts_files=parts_files)
     assert added is True
-    part = parts[PartKey(table_uuid=T1_UUID, part_name="all_0_0_0")]
-    assert part == Part(files={file_a.relative_path: PartFile(snapshot_file=file_a, servers={0})}, total_size=100)
+    part_files = parts_files[PartKey(table_uuid=T1_UUID, shard_name="shard_1", part_name="all_0_0_0")]
+    assert part_files == {file_a.relative_path: PartFile(snapshot_file=file_a, servers={0})}
 
 
 def test_add_file_to_parts_collects_all_servers() -> None:
@@ -129,10 +181,19 @@ def test_add_file_to_parts_collects_all_servers() -> None:
         hexdigest="0001",
     )
     parts = {}
+    tables_replicas = {
+        T1_UUID: [
+            DatabaseReplica(shard_name="shard_1", replica_name="node_1"),
+            DatabaseReplica(shard_name="shard_1", replica_name="node_2"),
+            DatabaseReplica(shard_name="shard_1", replica_name="node_3"),
+        ]
+    }
     for server_index in range(3):
-        add_file_to_parts(snapshot_file=file_a, server_index=server_index, table_uuids={T1_UUID}, parts=parts)
-    part = parts[PartKey(table_uuid=T1_UUID, part_name="all_0_0_0")]
-    part_file = part.files[file_a.relative_path]
+        add_file_to_parts(
+            snapshot_file=file_a, server_index=server_index, tables_replicas=tables_replicas, parts_files=parts
+        )
+    part_files = parts[PartKey(table_uuid=T1_UUID, shard_name="shard_1", part_name="all_0_0_0")]
+    part_file = part_files[file_a.relative_path]
     assert part_file.servers == {0, 1, 2}
 
 
@@ -146,9 +207,10 @@ def test_add_file_to_parts_fails_on_inconsistent_file() -> None:
     )
     file_b = file_a.copy(update={"hexdigest": "0002"})
     parts = {}
-    add_file_to_parts(snapshot_file=file_a, server_index=0, table_uuids={T1_UUID}, parts=parts)
+    tables_replicas = {T1_UUID: DATABASES_REPLICAS}
+    add_file_to_parts(snapshot_file=file_a, server_index=0, tables_replicas=tables_replicas, parts_files=parts)
     with pytest.raises(ValueError):
-        add_file_to_parts(snapshot_file=file_b, server_index=1, table_uuids={T1_UUID}, parts=parts)
+        add_file_to_parts(snapshot_file=file_b, server_index=1, tables_replicas=tables_replicas, parts_files=parts)
 
 
 def test_add_file_to_parts_ignores_inconsistent_modification_time() -> None:
@@ -160,56 +222,22 @@ def test_add_file_to_parts_ignores_inconsistent_modification_time() -> None:
     )
     file_b = file_a.copy(update={"mtime_ns": 789789})
     parts = {}
-    add_file_to_parts(snapshot_file=file_a, server_index=0, table_uuids={T1_UUID}, parts=parts)
-    added = add_file_to_parts(snapshot_file=file_b, server_index=1, table_uuids={T1_UUID}, parts=parts)
+    tables_replicas = {T1_UUID: DATABASES_REPLICAS}
+    add_file_to_parts(snapshot_file=file_a, server_index=0, tables_replicas=tables_replicas, parts_files=parts)
+    added = add_file_to_parts(snapshot_file=file_b, server_index=1, tables_replicas=tables_replicas, parts_files=parts)
     assert added is True
 
 
-def test_add_file_to_parts_computes_total_part_size() -> None:
-    file_a = SnapshotFile(
-        relative_path=Path("store/000/00000000-0000-0000-0000-000000000001/detached/all_0_0_0/data.bin"),
-        file_size=1000,
-        mtime_ns=0,
-        hexdigest="0001",
-    )
-    file_b = SnapshotFile(
-        relative_path=Path("store/000/00000000-0000-0000-0000-000000000001/detached/all_0_0_0/checksums.txt"),
-        file_size=138,
-        mtime_ns=0,
-        hexdigest="0002",
-    )
-    parts = {}
-    for server_index in range(3):
-        add_file_to_parts(snapshot_file=file_a, server_index=server_index, table_uuids={T1_UUID}, parts=parts)
-        add_file_to_parts(snapshot_file=file_b, server_index=server_index, table_uuids={T1_UUID}, parts=parts)
-    # The total size was not tripled because of the multiple server
-    assert parts[PartKey(table_uuid=T1_UUID, part_name="all_0_0_0")].total_size == 1138
+def test_get_part_servers_succeeds_on_valid_parts() -> None:
+    get_part_servers([PartFile(snapshot_file=file, servers={0, 1}) for file in TABLE_1_PART_1])
+    get_part_servers([PartFile(snapshot_file=file, servers={0}) for file in TABLE_3_PART_1B])
 
 
-def test_check_parts_replication_succeeds_on_valid_parts() -> None:
-    parts = [
-        Part(
-            files={file.relative_path: PartFile(snapshot_file=file, servers={0, 1}) for file in TABLE_1_PART_1},
-            total_size=1120,
-        ),
-        Part(
-            files={file.relative_path: PartFile(snapshot_file=file, servers={0}) for file in TABLE_3_PART_1B},
-            total_size=1120,
-        ),
-    ]
-    check_parts_replication(parts)
-
-
-def test_check_parts_replication_fails_on_inconsistent_servers_set() -> None:
-    parts = [
-        Part(
-            files={file.relative_path: PartFile(snapshot_file=file, servers={0, 1}) for file in TABLE_1_PART_1},
-            total_size=1120,
-        )
-    ]
-    list(parts[0].files.values())[1].servers = {0, 1, 2}
+def test_get_part_servers_fails_on_inconsistent_servers_set() -> None:
+    part_files = [PartFile(snapshot_file=file, servers={0, 1}) for file in TABLE_1_PART_1]
+    part_files[1].servers = {0, 1, 2}
     with pytest.raises(ValueError):
-        check_parts_replication(parts)
+        get_part_servers(part_files)
 
 
 def test_distribute_parts_to_servers_balances_parts() -> None:

--- a/tests/unit/coordinator/plugins/clickhouse/test_replication.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_replication.py
@@ -1,0 +1,70 @@
+"""
+Copyright (c) 2021 Aiven Ltd
+See LICENSE for details
+"""
+from astacus.coordinator.plugins.clickhouse.macros import Macros
+from astacus.coordinator.plugins.clickhouse.manifest import ReplicatedDatabase, Table
+from astacus.coordinator.plugins.clickhouse.replication import DatabaseReplica, get_databases_replicas, get_tables_replicas
+from uuid import UUID
+
+
+def test_get_databases_replicas() -> None:
+    replicated_database = [
+        ReplicatedDatabase(name=b"default_db", uuid=UUID(int=0), shard=b"{all_shard}", replica=b"{my_replica}"),
+        ReplicatedDatabase(name=b"sharded_db", uuid=UUID(int=1), shard=b"{my_shard}", replica=b"{my_replica}"),
+    ]
+    server_macros = [
+        Macros.from_mapping({b"all_shard": b"all", b"my_shard": b"s1", b"my_replica": b"r1"}),
+        Macros.from_mapping({b"all_shard": b"all", b"my_shard": b"s2", b"my_replica": b"r2"}),
+    ]
+    databases_replicas = get_databases_replicas(replicated_database, server_macros)
+    assert databases_replicas == {
+        b"default_db": [
+            DatabaseReplica(shard_name="all", replica_name="r1"),
+            DatabaseReplica(shard_name="all", replica_name="r2"),
+        ],
+        b"sharded_db": [
+            DatabaseReplica(shard_name="s1", replica_name="r1"),
+            DatabaseReplica(shard_name="s2", replica_name="r2"),
+        ],
+    }
+
+
+def test_get_tables_replicas() -> None:
+    replicated_tables = [
+        Table(
+            database=b"default_db",
+            name=b"table_one",
+            engine="ReplicatedMergeTree",
+            uuid=UUID(int=3),
+            create_query=b"CREATE ...",
+        ),
+        Table(
+            database=b"sharded_db",
+            name=b"table_two",
+            engine="ReplicatedMergeTree",
+            uuid=UUID(int=4),
+            create_query=b"CREATE ...",
+        ),
+    ]
+    databases_replicas = {
+        b"default_db": [
+            DatabaseReplica(shard_name="all", replica_name="r1"),
+            DatabaseReplica(shard_name="all", replica_name="r2"),
+        ],
+        b"sharded_db": [
+            DatabaseReplica(shard_name="s1", replica_name="r1"),
+            DatabaseReplica(shard_name="s2", replica_name="r2"),
+        ],
+    }
+    tables_replicas = get_tables_replicas(replicated_tables, databases_replicas)
+    assert tables_replicas == {
+        UUID(int=3): [
+            DatabaseReplica(shard_name="all", replica_name="r1"),
+            DatabaseReplica(shard_name="all", replica_name="r2"),
+        ],
+        UUID(int=4): [
+            DatabaseReplica(shard_name="s1", replica_name="r1"),
+            DatabaseReplica(shard_name="s2", replica_name="r2"),
+        ],
+    }

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -490,6 +490,13 @@ async def test_distribute_parts_of_replicated_tables() -> None:
         ],
     )
     context.set_result(RetrieveDatabasesAndTablesStep, (SAMPLE_DATABASES, SAMPLE_TABLES))
+    context.set_result(
+        RetrieveMacrosStep,
+        [
+            Macros.from_mapping({b"my_shard": b"shard_1", b"my_replica": b"replica_1"}),
+            Macros.from_mapping({b"my_shard": b"shard_1", b"my_replica": b"replica_2"}),
+        ],
+    )
     await step.run_step(Cluster(nodes=[]), context)
     snapshot_results = context.get_result(SnapshotStep)
     # On the ReplicatedMergeTree table (uuid ending in 0001), each server has only half the parts now

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -11,6 +11,7 @@ from astacus.coordinator.config import CoordinatorNode
 from astacus.coordinator.plugins.base import BackupManifestStep, SnapshotStep, StepFailedError, StepsContext
 from astacus.coordinator.plugins.clickhouse.client import ClickHouseClient, StubClickHouseClient
 from astacus.coordinator.plugins.clickhouse.config import ClickHouseConfiguration, ClickHouseNode, ReplicatedDatabaseSettings
+from astacus.coordinator.plugins.clickhouse.macros import Macros, MACROS_LIST_QUERY
 from astacus.coordinator.plugins.clickhouse.manifest import AccessEntity, ClickHouseManifest, ReplicatedDatabase, Table
 from astacus.coordinator.plugins.clickhouse.replication import DatabaseReplica
 from astacus.coordinator.plugins.clickhouse.steps import (
@@ -19,13 +20,13 @@ from astacus.coordinator.plugins.clickhouse.steps import (
     DistributeReplicatedPartsStep,
     FreezeTablesStep,
     ListDatabaseReplicasStep,
-    MACROS_LIST_QUERY,
     PrepareClickHouseManifestStep,
     RemoveFrozenTablesStep,
     RestoreAccessEntitiesStep,
     RestoreReplicatedDatabasesStep,
     RetrieveAccessEntitiesStep,
     RetrieveDatabasesAndTablesStep,
+    RetrieveMacrosStep,
     SyncDatabaseReplicasStep,
     SyncTableReplicasStep,
     TABLES_LIST_QUERY,
@@ -339,6 +340,30 @@ async def test_retrieve_tables_without_any_table() -> None:
 
 
 @pytest.mark.asyncio
+async def test_retrieve_macros() -> None:
+    clients = [StubClickHouseClient(), StubClickHouseClient()]
+    for (
+        client,
+        replica_name,
+    ) in zip(clients, [b"node_1", b"node_2"]):
+        client.set_response(
+            MACROS_LIST_QUERY,
+            [
+                [b64_str(b"shard"), b64_str(b"a_shard")],
+                [b64_str(b"replica"), b64_str(replica_name)],
+            ],
+        )
+    step = RetrieveMacrosStep(clients=clients)
+    cluster = Cluster(nodes=[CoordinatorNode(url="node1"), CoordinatorNode(url="node2")])
+    context = StepsContext()
+    servers_macros = await step.run_step(cluster, context)
+    assert servers_macros == [
+        Macros.from_mapping({b"shard": b"a_shard", b"replica": b"node_1"}),
+        Macros.from_mapping({b"shard": b"a_shard", b"replica": b"node_2"}),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_create_clickhouse_manifest() -> None:
     step = PrepareClickHouseManifestStep()
     context = StepsContext()
@@ -562,18 +587,7 @@ async def test_parse_clickhouse_manifest() -> None:
 
 @pytest.mark.asyncio
 async def test_list_database_replicas_step() -> None:
-    clients = [StubClickHouseClient(), StubClickHouseClient()]
-    for client, replica_name, shard_a, shard_b in zip(clients, [b"node1", b"node2"], [b"a1", b"a2"], [b"b1", b"b2"]):
-        client.set_response(
-            MACROS_LIST_QUERY,
-            [
-                [b64_str(b"shard_group_a"), b64_str(shard_a)],
-                [b64_str(b"shard_group_b"), b64_str(shard_b)],
-                [b64_str(b"replica"), b64_str(replica_name)],
-                [b64_str(b"don\x80care"), b64_str(b"its\x00fine")],
-            ],
-        )
-    step = ListDatabaseReplicasStep(clients=clients)
+    step = ListDatabaseReplicasStep()
     cluster = Cluster(nodes=[CoordinatorNode(url="node1"), CoordinatorNode(url="node2")])
     context = StepsContext()
     context.set_result(
@@ -584,6 +598,13 @@ async def test_list_database_replicas_step() -> None:
                 ReplicatedDatabase(name=b"db-two", shard=b"{shard_group_b}", replica=b"{replica}_suf"),
             ]
         ),
+    )
+    context.set_result(
+        RetrieveMacrosStep,
+        [
+            Macros.from_mapping({b"shard_group_a": b"a1", b"shard_group_b": b"b1", b"replica": b"node1"}),
+            Macros.from_mapping({b"shard_group_a": b"a2", b"shard_group_b": b"b2", b"replica": b"node2"}),
+        ],
     )
     database_replicas = await step.run_step(cluster, context)
     assert database_replicas == {
@@ -601,15 +622,15 @@ async def test_list_database_replicas_step() -> None:
 @pytest.mark.parametrize("missing_macro", [b"shard", b"replica"])
 @pytest.mark.asyncio
 async def test_list_database_replicas_step_fails_on_missing_macro(missing_macro: bytes) -> None:
-    clients = [StubClickHouseClient(), StubClickHouseClient()]
-    for client, replica_name in zip(clients, [b"node1", b"node2"]):
-        response = []
-        if missing_macro != b"shard":
-            response.append([b64_str(b"shard"), b64_str(b"all")])
-        if missing_macro != b"replica":
-            response.append([b64_str(b"replica"), b64_str(replica_name)])
-        client.set_response(MACROS_LIST_QUERY, response)
-    step = ListDatabaseReplicasStep(clients=clients)
+    server_1_macros = Macros()
+    server_2_macros = Macros()
+    if missing_macro != b"shard":
+        server_1_macros.add(b"shard", b"s1")
+        server_2_macros.add(b"shard", b"s1")
+    elif missing_macro != b"replica":
+        server_1_macros.add(b"replica", b"r1")
+        server_2_macros.add(b"replica", b"r2")
+    step = ListDatabaseReplicasStep()
     cluster = Cluster(nodes=[CoordinatorNode(url="node1"), CoordinatorNode(url="node2")])
     context = StepsContext()
     context.set_result(
@@ -620,6 +641,7 @@ async def test_list_database_replicas_step_fails_on_missing_macro(missing_macro:
             ]
         ),
     )
+    context.set_result(RetrieveMacrosStep, [server_1_macros, server_2_macros])
     with pytest.raises(StepFailedError, match=f"Error in macro of server 1: No macro named {missing_macro!r}"):
         await step.run_step(cluster, context)
 


### PR DESCRIPTION
When building a backup manifest, we used to alter how files will be
restored by de-duplicating MergeTree table parts that were identical
on all servers of a cluster.

Now, we do the same thing but instead of de-duplicating across all
servers, we only do that within a single shard.

In general, each Replicated table can have a different sharding
configuration.

In practice, using the Replicated database engine, all tables inside
the same database will have the same sharding configuration.

We use this information to infer the sharding configuration of each
table, and then distribute parts of each tables according to that
configuration.

The restore operation is essentially oblivious to that manipulation.

As long as the cluster where the data is restored has the same
shape (same number of servers with the same sharding configuration
for each database), the data will be restored once per shard.

ClickHouse will replicate the data within each shard, like it already
did when the entire cluster was a single shard.