### PR TITLE
clickhouse: increase CREATE/DROP DATABASE timeout and concurrency

### DIFF
--- a/astacus/common/limiter.py
+++ b/astacus/common/limiter.py
@@ -2,7 +2,7 @@
 Copyright (c) 2021 Aiven Ltd
 See LICENSE for details
 """
-from typing import Awaitable
+from typing import Awaitable, Iterable
 
 import asyncio
 
@@ -14,3 +14,8 @@ class Limiter:
     async def run(self, awaitable: Awaitable) -> None:
         async with self.semaphore:
             await awaitable
+
+
+async def gather_limited(limit: int, awaitables: Iterable[Awaitable]) -> None:
+    limiter = Limiter(limit)
+    await asyncio.gather(*[limiter.run(awaitable) for awaitable in awaitables])

--- a/astacus/coordinator/plugins/clickhouse/plugin.py
+++ b/astacus/coordinator/plugins/clickhouse/plugin.py
@@ -47,9 +47,13 @@ class ClickHousePlugin(CoordinatorPlugin):
     replicated_databases_zookeeper_path: str = "/clickhouse/databases"
     replicated_databases_settings: ReplicatedDatabaseSettings = ReplicatedDatabaseSettings()
     freeze_name: str = "astacus"
+    drop_databases_timeout: float = 300.0
+    max_concurrent_drop_databases: int = 100
+    create_databases_timeout: float = 60.0
+    max_concurrent_create_databases: int = 100
+    sync_databases_timeout: float = 60.0
     attach_timeout: float = 300.0
     max_concurrent_attach: int = 100
-    sync_databases_timeout: float = 60.0
     sync_tables_timeout: float = 3600.0
     max_concurrent_sync: int = 100
 
@@ -108,6 +112,10 @@ class ClickHousePlugin(CoordinatorPlugin):
                 clients=clients,
                 replicated_databases_zookeeper_path=self.replicated_databases_zookeeper_path,
                 replicated_database_settings=self.replicated_databases_settings,
+                drop_databases_timeout=self.drop_databases_timeout,
+                max_concurrent_drop_databases=self.max_concurrent_drop_databases,
+                create_databases_timeout=self.create_databases_timeout,
+                max_concurrent_create_database=self.max_concurrent_create_databases,
             ),
             SyncDatabaseReplicasStep(
                 zookeeper_client=zookeeper_client,

--- a/tests/unit/common/test_limiter.py
+++ b/tests/unit/common/test_limiter.py
@@ -3,7 +3,7 @@ Copyright (c) 2021 Aiven Ltd
 See LICENSE for details
 """
 
-from astacus.common.limiter import Limiter
+from astacus.common.limiter import gather_limited, Limiter
 from typing import Sequence
 
 import asyncio
@@ -32,5 +32,33 @@ async def test_limiter(limit: int, expected_trace: Sequence[str]) -> None:
         limiter.run(add_trace("s1", 0.1, "e1")),
         limiter.run(add_trace("s2", 0.01, "e2")),
         limiter.run(add_trace("s3", 0.03, "e3")),
+    )
+    assert trace == expected_trace
+
+
+@pytest.mark.parametrize(
+    "limit,expected_trace",
+    [
+        (1, ["s1", "e1", "s2", "e2", "s3", "e3"]),
+        (2, ["s1", "s2", "e2", "s3", "e3", "e1"]),
+        (3, ["s1", "s2", "s3", "e2", "e3", "e1"]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_gather_limited(limit: int, expected_trace: Sequence[str]) -> None:
+    trace = []
+
+    async def add_trace(start: str, sleep: float, stop: str):
+        trace.append(start)
+        await asyncio.sleep(sleep)
+        trace.append(stop)
+
+    await gather_limited(
+        limit,
+        [
+            add_trace("s1", 0.1, "e1"),
+            add_trace("s2", 0.01, "e2"),
+            add_trace("s3", 0.03, "e3"),
+        ],
     )
     assert trace == expected_trace


### PR DESCRIPTION
With larger databases, if the first restoration fails, we need to drop a database,
this can take quite some time. Increase the default timeout to 300sec.

Since this can take some time, parallelize the operations, this can be very
beneficial on large clusters.

While we're changing this area, also parallelize the CREATE DATABASE
and increase the timeout, this should speed-up restoration on large clusters.