### PR TITLE
cassandra: add asyncio marker for async tests

### DIFF
--- a/tests/unit/coordinator/plugins/cassandra/test_plugin.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_plugin.py
@@ -18,6 +18,7 @@ def fixture_cplugin(mocker, tmpdir):
     yield plugin.CassandraPlugin(client=ctc.cassandra_client_config)
 
 
+@pytest.mark.asyncio
 async def test_step_cassandrasubop(mocker):
     plugin = pytest.importorskip("astacus.coordinator.plugins.cassandra.plugin")
     mocker.patch.object(plugin, "run_subop")
@@ -30,6 +31,7 @@ async def test_step_cassandrasubop(mocker):
 
 
 @pytest.mark.parametrize("success", [False, True])
+@pytest.mark.asyncio
 async def test_step_cassandra_validate_configuration(mocker, success):
     plugin = pytest.importorskip("astacus.coordinator.plugins.cassandra.plugin")
     step = plugin.ValidateConfigurationStep(nodes=[])

--- a/tests/unit/coordinator/plugins/cassandra/test_restore_steps.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_restore_steps.py
@@ -14,6 +14,7 @@ import pytest
 
 
 @pytest.mark.parametrize("override_tokens", [False, True])
+@pytest.mark.asyncio
 async def test_step_start_cassandra(mocker, override_tokens):
     restore_steps = pytest.importorskip("astacus.coordinator.plugins.cassandra.model.restore_steps")
     cassandra_schema = pytest.importorskip("astacus.common.cassandra.schema")
@@ -75,6 +76,7 @@ class AsyncIterableWrapper:
 
 
 @pytest.mark.parametrize("steps,success", [([True], True), ([False, True], True), ([False], False)])
+@pytest.mark.asyncio
 async def test_step_wait_cassandra_up(mocker, steps, success):
     restore_steps = pytest.importorskip("astacus.coordinator.plugins.cassandra.model.restore_steps")
     get_schema_steps = steps[:]

--- a/tests/unit/coordinator/plugins/cassandra/test_utils.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_utils.py
@@ -12,6 +12,7 @@ import pytest
 
 
 @pytest.mark.parametrize("start_ok", [False, True])
+@pytest.mark.asyncio
 async def test_run_subop(mocker, start_ok):
     async def request_from_nodes(*args, **kwargs):
         if start_ok:
@@ -40,6 +41,7 @@ async def test_run_subop(mocker, start_ok):
         ([1], (1, "")),
     ],
 )
+@pytest.mark.asyncio
 async def test_get_schema_hash(mocker, hashes, result):
     mocker.patch.object(utils, "run_subop", return_value=[SimpleNamespace(schema_hash=hash) for hash in hashes])
     actual_result = await utils.get_schema_hash(None)


### PR DESCRIPTION
Tests were skipped because of the missing marker.