### PR TITLE
clickhouse: add support and tests for ClickHouse 22.8

### DIFF
--- a/astacus/coordinator/plugins/clickhouse/README.md
+++ b/astacus/coordinator/plugins/clickhouse/README.md
@@ -49,7 +49,8 @@
     "wait_entry_commited_timeout_sec": 3600,
     "cluster_username": "distributed_user",
     "cluster_password": "distributed_user_password",
-    "cluster_secret": "the secret"
+    "cluster_secret": "the secret",
+    "collection_name": null
   },
   "freeze_name": "astacus",
   "sync_timeout": 3600

--- a/astacus/coordinator/plugins/clickhouse/config.py
+++ b/astacus/coordinator/plugins/clickhouse/config.py
@@ -27,6 +27,7 @@ class ReplicatedDatabaseSettings(AstacusModel):
     cluster_username: Optional[str]
     cluster_password: Optional[str]
     cluster_secret: Optional[str]
+    collection_name: Optional[str]
 
 
 def get_zookeeper_client(configuration: ZooKeeperConfiguration) -> ZooKeeperClient:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import platform
 import pytest
 
 CLICKHOUSE_PATH_OPTION = "--clickhouse-path"
+CLICKHOUSE_RESTORE_PATH_OPTION = "--clickhouse-restore-path"
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -19,6 +20,13 @@ def pytest_addoption(parser: Parser) -> None:
         type=checked_path_to_file,
         default=None,
         help="Path to the ClickHouse binary used in integration tests (default: auto-detected)",
+    )
+    parser.addoption(
+        CLICKHOUSE_RESTORE_PATH_OPTION,
+        action="store",
+        type=checked_path_to_file,
+        default=None,
+        help="Path to the ClickHouse binary used for restoring in integration tests (default: use the same as for backup)",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,42 @@
 Copyright (c) 2022 Aiven Ltd
 See LICENSE for details
 """
+from _pytest.config.argparsing import Parser
+from argparse import ArgumentTypeError
+from pathlib import Path
 
 import platform
 import pytest
 
+CLICKHOUSE_PATH_OPTION = "--clickhouse-path"
+
+
+def pytest_addoption(parser: Parser) -> None:
+    parser.addoption(
+        CLICKHOUSE_PATH_OPTION,
+        action="store",
+        type=checked_path_to_file,
+        default=None,
+        help="Path to the ClickHouse binary used in integration tests (default: auto-detected)",
+    )
+
 
 def pytest_runtest_setup(item):
     if any(item.iter_markers(name="x86_64")) and platform.machine() != "x86_64":
-
         pytest.skip("x86_64 arch required")
+
+
+def checked_path_to_file(option_value: str) -> Path:
+    """Return an absolute path to a file that exists and can be opened.
+
+    Relative paths are converted to absolute path using the current working directory.
+
+    Fails with an ArgumentTypeError describing the issue (file not found, not a file, etc.) if the file cannot be opened.
+    """
+    option_path = Path(option_value).absolute()
+    try:
+        with option_path.open():
+            pass
+    except OSError as e:
+        raise ArgumentTypeError(str(e)) from e
+    return option_path

--- a/tests/integration/coordinator/plugins/clickhouse/conftest.py
+++ b/tests/integration/coordinator/plugins/clickhouse/conftest.py
@@ -47,7 +47,7 @@ class ClickHouseServiceCluster(ServiceCluster):
 
 
 USER_CONFIG = """
-    <yandex>
+    <clickhouse>
         <users>
             <default>
                 <password>secret</password>
@@ -60,7 +60,7 @@ USER_CONFIG = """
             </default>
         </profiles>
         <quotas><default></default></quotas>
-    </yandex>
+    </clickhouse>
 """
 
 
@@ -170,7 +170,7 @@ def create_clickhouse_configs(
     )
     return [
         f"""
-                <yandex>
+                <clickhouse>
                     <path>{str(data_dir)}</path>
                     <logger>
                         <level>debug</level>
@@ -211,7 +211,7 @@ def create_clickhouse_configs(
                         <my_shard>{cluster_shard}</my_shard>
                         <my_replica>r{http_port}</my_replica>
                     </macros>
-                </yandex>
+                </clickhouse>
                 """
         for cluster_shard, data_dir, tcp_port, http_port, interserver_http_port in zip(
             cluster_shards, data_dirs, tcp_ports, http_ports, interserver_http_ports

--- a/tests/integration/coordinator/plugins/clickhouse/conftest.py
+++ b/tests/integration/coordinator/plugins/clickhouse/conftest.py
@@ -21,7 +21,7 @@ from astacus.coordinator.plugins.clickhouse.plugin import ClickHousePlugin
 from astacus.coordinator.plugins.zookeeper_config import ZooKeeperConfiguration, ZooKeeperNode
 from astacus.node.config import NodeConfig
 from pathlib import Path
-from tests.conftest import CLICKHOUSE_PATH_OPTION
+from tests.conftest import CLICKHOUSE_PATH_OPTION, CLICKHOUSE_RESTORE_PATH_OPTION
 from tests.integration.conftest import get_command_path, Ports, run_process_and_wait_for_pattern, Service, ServiceCluster
 from tests.system.conftest import background_process, wait_url_up
 from tests.utils import CONSTANT_TEST_RSA_PRIVATE_KEY, CONSTANT_TEST_RSA_PUBLIC_KEY
@@ -77,6 +77,18 @@ async def fixture_clickhouse_command(request: FixtureRequest) -> ClickHouseComma
         clickhouse_path = await get_command_path("clickhouse-server")
     if clickhouse_path is None:
         pytest.skip("clickhouse installation not found")
+    return get_clickhouse_command(clickhouse_path)
+
+
+@pytest.fixture(scope="module", name="clickhouse_restore_command")
+def fixture_clickhouse_restore_command(request: FixtureRequest, clickhouse_command: ClickHouseCommand) -> ClickHouseCommand:
+    clickhouse_restore_path = request.config.getoption(CLICKHOUSE_RESTORE_PATH_OPTION)
+    if clickhouse_restore_path is None:
+        return clickhouse_command
+    return get_clickhouse_command(clickhouse_restore_path)
+
+
+def get_clickhouse_command(clickhouse_path: Path) -> ClickHouseCommand:
     return [clickhouse_path] if clickhouse_path.name.endswith("-server") else [clickhouse_path, "server"]
 
 

--- a/tests/integration/coordinator/plugins/clickhouse/test_client.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_client.py
@@ -2,7 +2,7 @@
 Copyright (c) 2021 Aiven Ltd
 See LICENSE for details
 """
-from .conftest import create_clickhouse_service, get_clickhouse_client
+from .conftest import ClickHouseCommand, create_clickhouse_service, get_clickhouse_client
 from astacus.coordinator.plugins.clickhouse.client import ClickHouseClientQueryError
 from tests.integration.conftest import Ports, Service
 
@@ -40,8 +40,8 @@ async def test_client_execute_with_empty_response(clickhouse: Service) -> None:
 
 
 @pytest.mark.asyncio
-async def test_client_execute_bounded_connection_failure_time(ports: Ports) -> None:
-    async with create_clickhouse_service(ports) as clickhouse:
+async def test_client_execute_bounded_connection_failure_time(ports: Ports, clickhouse_command: ClickHouseCommand) -> None:
+    async with create_clickhouse_service(ports, clickhouse_command) as clickhouse:
         client = get_clickhouse_client(clickhouse, timeout=1.0)
         clickhouse.process.kill()
         start_time = time.monotonic()

--- a/tests/integration/coordinator/plugins/clickhouse/test_plugin.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_plugin.py
@@ -65,11 +65,13 @@ async def fixture_restored_cluster(
     restorable_cluster: Path,
     ports: Ports,
     request: SubRequest,
-    clickhouse_command: ClickHouseCommand,
+    clickhouse_restore_command: ClickHouseCommand,
 ) -> AsyncIterable[Sequence[ClickHouseClient]]:
     stop_after_step: str = request.param
     async with create_zookeeper(ports) as zookeeper:
-        async with create_clickhouse_cluster(zookeeper, ports, ("s1", "s1", "s2"), clickhouse_command) as clickhouse_cluster:
+        async with create_clickhouse_cluster(
+            zookeeper, ports, ("s1", "s1", "s2"), clickhouse_restore_command
+        ) as clickhouse_cluster:
             clients = [get_clickhouse_client(service) for service in clickhouse_cluster.services]
             async with create_astacus_cluster(restorable_cluster, zookeeper, clickhouse_cluster, ports) as astacus_cluster:
                 # To test if we can survive transient failures during an entire restore operation,

--- a/tests/integration/coordinator/plugins/clickhouse/test_plugin.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_plugin.py
@@ -10,6 +10,7 @@ from astacus.coordinator.plugins.clickhouse.plugin import ClickHousePlugin
 from pathlib import Path
 from tests.integration.conftest import create_zookeeper, Ports
 from tests.integration.coordinator.plugins.clickhouse.conftest import (
+    ClickHouseCommand,
     create_astacus_cluster,
     create_clickhouse_cluster,
     get_clickhouse_client,
@@ -43,11 +44,13 @@ def get_restore_steps_names() -> List[str]:
 
 
 @pytest.fixture(scope="module", name="restorable_cluster")
-async def fixture_restorable_cluster(ports: Ports) -> AsyncIterator[Path]:
+async def fixture_restorable_cluster(ports: Ports, clickhouse_command: ClickHouseCommand) -> AsyncIterator[Path]:
     with tempfile.TemporaryDirectory(prefix="storage_") as storage_path_str:
         storage_path = Path(storage_path_str)
         async with create_zookeeper(ports) as zookeeper:
-            async with create_clickhouse_cluster(zookeeper, ports, ("s1", "s1", "s2")) as clickhouse_cluster:
+            async with create_clickhouse_cluster(
+                zookeeper, ports, ("s1", "s1", "s2"), clickhouse_command
+            ) as clickhouse_cluster:
                 async with create_astacus_cluster(storage_path, zookeeper, clickhouse_cluster, ports) as astacus_cluster:
                     clients = [get_clickhouse_client(service) for service in clickhouse_cluster.services]
                     await setup_cluster_content(clients, clickhouse_cluster.use_named_collections)
@@ -62,10 +65,11 @@ async def fixture_restored_cluster(
     restorable_cluster: Path,
     ports: Ports,
     request: SubRequest,
+    clickhouse_command: ClickHouseCommand,
 ) -> AsyncIterable[Sequence[ClickHouseClient]]:
     stop_after_step: str = request.param
     async with create_zookeeper(ports) as zookeeper:
-        async with create_clickhouse_cluster(zookeeper, ports, ("s1", "s1", "s2")) as clickhouse_cluster:
+        async with create_clickhouse_cluster(zookeeper, ports, ("s1", "s1", "s2"), clickhouse_command) as clickhouse_cluster:
             clients = [get_clickhouse_client(service) for service in clickhouse_cluster.services]
             async with create_astacus_cluster(restorable_cluster, zookeeper, clickhouse_cluster, ports) as astacus_cluster:
                 # To test if we can survive transient failures during an entire restore operation,

--- a/tests/integration/coordinator/plugins/clickhouse/test_replication.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_replication.py
@@ -4,7 +4,11 @@ See LICENSE for details
 """
 from astacus.coordinator.plugins.clickhouse.replication import get_shard_and_replica
 from tests.integration.conftest import create_zookeeper, Ports
-from tests.integration.coordinator.plugins.clickhouse.conftest import create_clickhouse_cluster, get_clickhouse_client
+from tests.integration.coordinator.plugins.clickhouse.conftest import (
+    ClickHouseCommand,
+    create_clickhouse_cluster,
+    get_clickhouse_client,
+)
 
 import pytest
 
@@ -15,9 +19,9 @@ pytestmark = [
 
 
 @pytest.mark.asyncio
-async def test_get_shard_and_replica(ports: Ports) -> None:
+async def test_get_shard_and_replica(ports: Ports, clickhouse_command: ClickHouseCommand) -> None:
     async with create_zookeeper(ports) as zookeeper:
-        async with create_clickhouse_cluster(zookeeper, ports, cluster_shards=["s1"]) as clickhouse_cluster:
+        async with create_clickhouse_cluster(zookeeper, ports, ["s1"], clickhouse_command) as clickhouse_cluster:
             clickhouse = clickhouse_cluster.services[0]
             client = get_clickhouse_client(clickhouse)
             await client.execute(

--- a/tests/integration/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_steps.py
@@ -76,6 +76,10 @@ async def test_retrieve_tables(ports: Ports) -> None:
                     replica=b"{my_replica}",
                 ),
             ]
+            zookeeper_path = (
+                f"/clickhouse/tables/{str(table_uuid)}/{{my_shard}}"
+                if clickhouse_cluster.expands_uuid_in_zookeeper_path else "/clickhouse/tables/{uuid}/{my_shard}"
+            )
             assert tables == [
                 Table(
                     database="has_tablés".encode(),
@@ -85,7 +89,7 @@ async def test_retrieve_tables(ports: Ports) -> None:
                     create_query=(
                         f"CREATE TABLE `has_tablés`.`tablé_1` UUID '{str(table_uuid)}' (`thekey` UInt32) "
                         f"ENGINE = "
-                        f"ReplicatedMergeTree('/clickhouse/tables/{str(table_uuid)}/{{my_shard}}', '{{my_replica}}') "
+                        f"ReplicatedMergeTree('{zookeeper_path}', '{{my_replica}}') "
                         f"ORDER BY thekey SETTINGS index_granularity = 8192"
                     ).encode(),
                     dependencies=[],


### PR DESCRIPTION
The only real new feature is supporting a different way of authenticating Replicated
databases, using a named collection (available since ClickHouse 22.4).

The rest is extending the test setup to handle minor differences in tables metadata
and giving some tools to test the transition between two different ClickHouse versions.