### PR TITLE
Update linters and typing

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -32,11 +32,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -47,7 +47,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -61,4 +61,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,15 +4,15 @@ on: pull_request
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         run: make build-dep-ubuntu
 
       - name: Set up Python 3.10 with caching
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -24,9 +24,9 @@ jobs:
         run: make lint
 
   copyright:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       steps:
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v3
 
         - name: Enforce copyright headers
           run: make copyright

--- a/.github/workflows/tests-all.yml
+++ b/.github/workflows/tests-all.yml
@@ -8,19 +8,19 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 4
       matrix:
         python-version: ['3.9', '3.10']
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Install dependencies
       run: make build-dep-ubuntu test-dep-ubuntu
 
     - name: Set up Python ${{ matrix.python-version }} with caching
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,19 +6,19 @@ on: pull_request
 
 jobs:
   unit-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 4
       matrix:
         python-version: ['3.9']
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Install dependencies
       run: make build-dep-ubuntu test-dep-ubuntu
 
     - name: Set up Python ${{ matrix.python-version }} with caching
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,13 +41,15 @@ repos:
         args:
           - --rcfile=.pylintrc
 
-  # https://pre-commit.com/#repository-local-hooks
-  - repo: local
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910
     hooks:
       - id: mypy
-        name: mypy
-        entry: mypy
-        language: system
-        types: [python]
-        files: \.py$
         exclude: ^setup.py|^tests/|^vendor/|^astacus/proto/
+        additional_dependencies:
+          - types-PyYAML>=6.0.12.2
+          - types-requests>=2.28.11.5
+          - types-tabulate>=0.9.0.0
+          - types-urllib3>=1.26.25.4
+          - typing_extensions>=3.10.0
+          - pydantic==1.7.4

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,22 +1,17 @@
-[MASTER]
-string-quote=double-avoid-escape
-triple-quote=double
-docstring-quote=double
-
 [MESSAGES CONTROL]
 disable=
-    bad-continuation,
-    duplicate-code,                # the checker in 2.9.6 fails with parallelism
-    invalid-name,                  # fastapi conventions break this
+    duplicate-code,                          # the checker in 2.9.6 fails with parallelism
+    invalid-name,                            # fastapi conventions break this
     missing-docstring,
-    no-member,                     # broken with pydantic + inheritance
-    no-self-use,                   # annoying when fullfilling some API
-    too-few-public-methods,        # some pydantic models have 0 and it is fine
+    no-member,                               # broken with pydantic + inheritance
+    too-few-public-methods,                  # some pydantic models have 0 and it is fine
     too-many-arguments,
-    too-many-instance-attributes,  # give me a break, <= 7
-    too-many-locals,               # locals make the code more readable
-    unused-argument,               # annoying when fullfilling some API
-    wrong-import-order,            # we use isort anyway
+    too-many-instance-attributes,            # give me a break, <= 7
+    too-many-locals,                         # locals make the code more readable
+    unused-argument,                         # annoying when fullfilling some API
+    use-implicit-booleaness-not-comparison,  # leads to unclear code
+    unspecified-encoding,                    # irrelevant since the library is linux-specific
+    wrong-import-order,                      # we use isort anyway
 
 [FORMAT]
 max-line-length=125

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 # -*- dockerfile -*-
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 MAINTAINER "Markus Stenberg <mstenber@aiven.io>"
 
 RUN apt-get update

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ podman-test-ubuntu:
 
 .PHONY: pip-outdated
 pip-outdated:
-	pip-outdated setup.cfg requirements.testing.txt
+	pip list --outdated
 
 
 # For development purposes, run server with the default astacus conf

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ ZOOKEEPER_HASH = 87e555869211cc3dc5f3cdfe7c22124b62605dac50a14e6c84e7e66b583c4eb
 
 default: $(GENERATED)
 
+venv: default
+	$(PYTHON) -m venv venv && source venv/bin/activate && pip install -U pip && pip install -r requirements.txt
+
 clean:
 	rm -rf rpm/ $(GENERATED)
 

--- a/astacus/client.py
+++ b/astacus/client.py
@@ -126,9 +126,11 @@ def print_list_result(result):
             ssize += b.upload_stored_size
 
         if tsize:
-            gtable[0]["pchanged"] = "%.2f%%" % (100.0 * usize / tsize)
+            pchanged = 100.0 * usize / tsize
+            gtable[0]["pchanged"] = f"{pchanged:.2f}%"
         if usize:
-            gtable[0]["csaving"] = "%.2f%%" % (100.0 - 100.0 * ssize / usize)
+            csaving = 100.0 - 100.0 * ssize / usize
+            gtable[0]["csaving"] = f"{csaving:.2f}%"
 
         if i:
             print()

--- a/astacus/common/etcd.py
+++ b/astacus/common/etcd.py
@@ -8,6 +8,7 @@ Minimal etcdv3 client library on top of httpx
 """
 
 from .utils import AstacusModel, httpx_request
+from typing import Optional
 
 import base64
 import json
@@ -38,7 +39,7 @@ class ETCDClient:
         url = f"{self.url}/{url}"
         return await httpx_request(url, caller=caller, method="post", data=json.dumps(data))
 
-    async def kv_deleterange(self, *, key: bytes, range_end: bytes = None):
+    async def kv_deleterange(self, *, key: bytes, range_end: Optional[bytes] = None):
         data = {"key": b64encode_to_str(key)}
         if range_end:
             data["range_end"] = b64encode_to_str(range_end)
@@ -46,7 +47,7 @@ class ETCDClient:
         result = await self._request("kv/deleterange", data, caller="ETCDClient.delete_range")
         return result
 
-    async def kv_range(self, *, key: bytes, range_end: bytes = None):
+    async def kv_range(self, *, key: bytes, range_end: Optional[bytes] = None):
         data = {"key": b64encode_to_str(key)}
         if range_end:
             data["range_end"] = b64encode_to_str(range_end)

--- a/astacus/common/rohmustorage.py
+++ b/astacus/common/rohmustorage.py
@@ -12,8 +12,7 @@ from .utils import AstacusModel
 from astacus.common import exceptions
 from enum import Enum
 from pydantic import DirectoryPath, Field
-from rohmu import rohmufile  # type: ignore
-from rohmu import errors
+from rohmu import errors, rohmufile
 from typing import Dict, Optional, Union
 from typing_extensions import Literal
 

--- a/astacus/common/statsd.py
+++ b/astacus/common/statsd.py
@@ -17,7 +17,7 @@ This is combination of:
 from .utils import AstacusModel
 from contextlib import asynccontextmanager, contextmanager
 from enum import Enum
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 import socket
 import time
@@ -28,7 +28,7 @@ class MessageFormat(str, Enum):
     telegraf = "telegraf"
 
 
-Tags = Dict[str, Union[int, str, None]]
+Tags = dict[str, Union[int, str, None]]
 
 
 class StatsdConfig(AstacusModel):
@@ -110,7 +110,7 @@ class StatsClient:
                 parts.append(pattern.format(separator, tag, val).encode("utf-8"))
         elif self._message_format == MessageFormat.telegraf:
             for tag, val in send_tags.items():
-                parts.insert(1, ",{}={}".format(tag, val).encode("utf-8"))
+                parts.insert(1, f",{tag}={val}".encode("utf-8"))
         else:
             raise NotImplementedError("Unsupported message format")
 

--- a/astacus/common/utils.py
+++ b/astacus/common/utils.py
@@ -8,6 +8,8 @@ See LICENSE for details
 Shared utilities (between coordinator and node)
 
 """
+from __future__ import annotations
+
 from abc import ABC
 from contextlib import contextmanager
 from multiprocessing.dummy import Pool  # fastapi + fork = bad idea
@@ -274,11 +276,12 @@ def timedelta_as_short_str(delta):
     return " ".join(f"{v}{u}" for v, u in [(delta.days, "d"), (h, "h"), (m, "m"), (s, "s")] if v)
 
 
-def size_as_short_str(s):
-    for u, m in [("T", 1e12), ("G", 1e9), ("M", 1e6), ("K", 1e3)]:
-        if s >= m:
-            return "%.1f %sB" % (s / m, u)
-    return f"{s} B"
+def size_as_short_str(size: int | float) -> str:
+    for unit, multiplier in [("T", 1e12), ("G", 1e9), ("M", 1e6), ("K", 1e3)]:
+        if size >= multiplier:
+            unit_size = size / multiplier
+            return f"{unit_size:.1f} {unit}B"
+    return f"{size} B"
 
 
 def parallel_map_to(*, fun, iterable, result_callback, n=None) -> bool:

--- a/astacus/coordinator/coordinator.py
+++ b/astacus/coordinator/coordinator.py
@@ -9,7 +9,7 @@ from astacus.common.dependencies import get_request_url
 from astacus.common.magic import ErrorCode
 from astacus.common.progress import Progress
 from astacus.common.rohmustorage import MultiRohmuStorage
-from astacus.common.statsd import StatsClient
+from astacus.common.statsd import StatsClient, Tags
 from astacus.common.storage import JsonStorage, MultiFileStorage, MultiStorage
 from astacus.common.utils import AsyncSleeper
 from astacus.coordinator.cluster import Cluster, LockResult, WaitResultError
@@ -269,7 +269,7 @@ class SteppedCoordinatorOp(LockedCoordinatorOp):
             for attempt in range(1, self.attempts + 1):
                 logger.debug("%s - attempt #%d/%d", name, attempt, self.attempts)
                 context = StepsContext(attempt=attempt)
-                stats_tags = {"op": name, "attempt": str(attempt)}
+                stats_tags: Tags = {"op": name, "attempt": str(attempt)}
                 async with self.stats.async_timing_manager("astacus_attempt_duration", stats_tags):
                     try:
                         if await self.try_run(cluster, context):

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -23,7 +23,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
-StepResult = TypeVar("StepResult", covariant=True)
+StepResult_co = TypeVar("StepResult_co", covariant=True)
 
 
 class CoordinatorPlugin(AstacusModel):
@@ -41,8 +41,8 @@ class OperationContext:
     hexdigest_storage: AsyncHexDigestStorage
 
 
-class Step(Generic[StepResult]):
-    async def run_step(self, cluster: Cluster, context: StepsContext) -> StepResult:
+class Step(Generic[StepResult_co]):
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> StepResult_co:
         raise NotImplementedError
 
 

--- a/astacus/server.py
+++ b/astacus/server.py
@@ -25,7 +25,7 @@ import logging
 import os
 import sentry_sdk
 import subprocess
-import uvicorn  # type:ignore
+import uvicorn
 
 logger = logging.getLogger(__name__)
 

--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -1,28 +1,30 @@
 # makefile convenience
-pre-commit>=2.14.1
+pre-commit>=2.20.0
 
 # pre-commit tasks in Makefile need these
-anyio==3.2.1
-mypy==0.910
-pylint==2.9.6
+anyio==3.3.1
+pylint==2.15.5
 pytest-asyncio==0.14.0
 pytest-cov==3.0.0
 pytest-mock==3.3.1
 pytest-order==1.0.0
 pytest-timeout==1.4.2
+pytest-watch==4.2.0
 pytest==6.2.4
 
+# pinning mypy to the same version as pre-commit
+mypy==0.910
+# types for things that don't seem to have them
+types-PyYAML>=6.0.12.2
+types-requests>=2.28.11.5
+types-tabulate>=0.9.0.0
+types-urllib3>=1.26.25.4
+typing_extensions>=3.10.0
+
 # fastapi testclient needs this yet does not depend on it, gnn
-requests
+requests>=2.28.1
 
 respx==0.16.3
 
 # convenience things that don't actually matter which version they are
-pip-outdated
-pytest-watch
-
-# types for things that don't seem to have them
-types-PyYAML
-types-requests
-types-tabulate
-types-urllib3
+pip-outdated>=0.5.0

--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -25,6 +25,3 @@ typing_extensions>=3.10.0
 requests>=2.28.1
 
 respx==0.16.3
-
-# convenience things that don't actually matter which version they are
-pip-outdated>=0.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,15 +9,17 @@ zip_safe = False
 
 # SKIP-IN-RPM
 install_requires =
-  PyYAML==5.4.1
-  fastapi==0.66.0
-  httpx==0.16.1
+  PyYAML==6.0
+  fastapi==0.70.1
+  httpx==0.17.1
   protobuf==3.14.0
-  rohmu==1.0.1
-  sentry-sdk==0.13.5
-  tabulate==0.8.9
-  typing-extensions==3.7.4.3
-  uvicorn==0.13.3
+  rohmu==1.0.7
+  sentry-sdk==1.6.0
+  tabulate==0.8.10
+  typing-extensions==3.10.0
+  uvicorn==0.15.0
+  # Pinned transitive deps
+  pydantic==1.7.4
 
   # Clickhouse support
-  kazoo
+  kazoo==2.8.0

--- a/tests/unit/coordinator/plugins/clickhouse/test_parts.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_parts.py
@@ -76,8 +76,7 @@ def test_group_files_into_parts_collects_parts_from_selected_tables() -> None:
         assert part.snapshot_files == original_files
         assert part.total_size == 1120
         assert part.servers == {0, 1}
-    assert other_files[0] == []
-    assert other_files[1] == []
+    assert other_files == [[], []]
 
 
 def test_group_files_into_parts_does_not_merge_unreplicated_parts_within_shard() -> None:

--- a/version_from_git.py
+++ b/version_from_git.py
@@ -16,7 +16,7 @@ def save_version(*, new_ver, old_ver, version_file):
     version_file = os.path.join(os.path.dirname(__file__), version_file)
     if not old_ver or new_ver != old_ver:
         with open(version_file, "w") as file_handle:
-            file_handle.write('"""{}"""\n__version__ = "{}"\n'.format(__doc__, new_ver))
+            file_handle.write(f'"""{__doc__}"""\n__version__ = "{new_ver}"\n')
     return True
 
 
@@ -35,7 +35,7 @@ def update_project_version(version_file):
     else:
         git_ver = git_out.splitlines()[0].strip().decode("utf-8")
         if "." not in git_ver:
-            git_ver = "0.0.1-0-unknown-{}".format(git_ver)
+            git_ver = f"0.0.1-0-unknown-{git_ver}"
         if save_version(new_ver=git_ver, old_ver=file_ver, version_file=version_file):
             return git_ver
 
@@ -48,7 +48,7 @@ def update_project_version(version_file):
             return short_ver
 
     if not file_ver:
-        raise Exception("version not available from git or from file {!r}".format(version_file))
+        raise Exception(f"version not available from git or from file {version_file!r}")
 
     return file_ver
 


### PR DESCRIPTION
This PR is a maintenance update that aims at improving CI and updating requirements.

It streamlines build and test requirements, updates pre-commit hook versions, fixes the errors surfaced by pylint and mypy, and normalizes formatting for markdown and yaml according to a prettier pre-commit hook.

This is a follow up of #95 and prepares the field for an update to python 3.11.