### PR TITLE
Fix clickhouse version CLI output parsing

### DIFF
--- a/tests/integration/coordinator/plugins/clickhouse/conftest.py
+++ b/tests/integration/coordinator/plugins/clickhouse/conftest.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from tests.conftest import CLICKHOUSE_PATH_OPTION, CLICKHOUSE_RESTORE_PATH_OPTION
 from tests.integration.conftest import get_command_path, Ports, run_process_and_wait_for_pattern, Service, ServiceCluster
 from tests.system.conftest import background_process, wait_url_up
-from tests.utils import CONSTANT_TEST_RSA_PRIVATE_KEY, CONSTANT_TEST_RSA_PUBLIC_KEY
+from tests.utils import CONSTANT_TEST_RSA_PRIVATE_KEY, CONSTANT_TEST_RSA_PUBLIC_KEY, get_clickhouse_version
 from typing import AsyncIterator, Awaitable, List, Sequence, Union
 
 import argparse
@@ -33,7 +33,6 @@ import contextlib
 import dataclasses
 import logging
 import pytest
-import subprocess
 import sys
 import tempfile
 
@@ -116,8 +115,7 @@ async def create_clickhouse_cluster(
     command: ClickHouseCommand,
 ) -> AsyncIterator[ClickHouseServiceCluster]:
     cluster_size = len(cluster_shards)
-    raw_clickhouse_version = subprocess.check_output([*command, "--version"]).strip().partition(b"version")[2]
-    clickhouse_version = tuple(int(part) for part in raw_clickhouse_version.split(b".") if part)
+    clickhouse_version = get_clickhouse_version(command)
     use_named_collections = clickhouse_version >= (22, 4)
     expands_uuid_in_zookeeper_path = clickhouse_version < (22, 4)
     tcp_ports = [ports.allocate() for _ in range(cluster_size)]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,19 @@
+"""
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+from collections.abc import Sequence
+from tests.utils import parse_clickhouse_version
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "version_command_output,expected_version",
+    [
+        (b"ClickHouse server version 22.0.0.1 (official build).", (22, 0, 0, 1)),
+        (b"ClickHouse server version 22.1.2.3.", (22, 1, 2, 3)),
+    ],
+)
+def test_parse_clickhouse_version(version_command_output: bytes, expected_version: Sequence[int]) -> None:
+    assert parse_clickhouse_version(version_command_output) == expected_version

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,9 +2,12 @@
 Copyright (c) 2020 Aiven Ltd
 See LICENSE for details
 """
-
 from astacus.common.rohmustorage import RohmuConfig
 from pathlib import Path
+from typing import List, Sequence, Union
+
+import re
+import subprocess
 
 # These test keys are from copied from pghoard
 
@@ -68,3 +71,16 @@ def create_rohmu_config(tmpdir, *, compression=True, encryption=True):
             }
         )
     return RohmuConfig.parse_obj(config)
+
+
+def parse_clickhouse_version(command_output: bytes) -> Sequence[int]:
+    version_match = re.search(r"([\d.]+\d)", command_output.decode())
+    if not version_match:
+        raise ValueError(f"Unable to parse version from command output: {command_output}")
+    version_tuple = tuple(int(part) for part in version_match.group(0).split(".") if part)
+    return version_tuple
+
+
+def get_clickhouse_version(command: List[Union[str, Path]]) -> Sequence[int]:
+    version_command_output = subprocess.check_output([*command, "--version"])
+    return parse_clickhouse_version(version_command_output)


### PR DESCRIPTION
Conftest ClickHouse version command output parsing fails for the latest official LTS build.