### PR TITLE
Update python to 3.11 and fix the test suite

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,17 @@
 [flake8]
 max-line-length = 125
+# E123: Closing brackets indent
+# E126: Hanging indents
+# E129: Visual indent
+# E203: Whitespace before ':' (in accordance with Black)
+# E231: Missing whitespace after ',' (in accordance with Black)
+# E501: Max line length
+# E722: bare-except
 extend-ignore =
-  E123,  # Closing brackets indent
-  E126,  # Hanging indents
-  E129,  # Visual indent
-  E203,  # Whitespace before ':' (in accordance with Black)
-  E231,  # Missing whitespace after ',' (in accordance with Black)
-  E501,  # Max line length
-  E722,  # bare-except
+  E123,
+  E126,
+  E129,
+  E203,
+  E231,
+  E501,
+  E722

--- a/.github/workflows/tests-all.yml
+++ b/.github/workflows/tests-all.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,4 +52,4 @@ repos:
           - types-tabulate>=0.9.0.0
           - types-urllib3>=1.26.25.4
           - typing_extensions>=3.10.0
-          - pydantic==1.7.4
+          - pydantic==1.10.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@ repos:
         exclude: ^vendor/
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         files: \.py$
@@ -42,7 +42,7 @@ repos:
           - --rcfile=.pylintrc
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v1.0.0
     hooks:
       - id: mypy
         exclude: ^setup.py|^tests/|^vendor/|^astacus/proto/

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,7 +4,6 @@ disable=
     invalid-name,                            # fastapi conventions break this
     missing-docstring,
     no-member,                               # broken with pydantic + inheritance
-    no-self-use,                             # sometimes overriden methods don't use self
     too-few-public-methods,                  # some pydantic models have 0 and it is fine
     too-many-arguments,
     too-many-instance-attributes,            # give me a break, <= 7

--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -6,6 +6,7 @@ See LICENSE for details
 # pydantic validators are class methods in disguise
 # pylint: disable=no-self-argument
 
+from .magic import StrEnum
 from .progress import Progress
 from .utils import AstacusModel, now, SizeLimitedFile
 from datetime import datetime
@@ -20,7 +21,7 @@ import socket
 
 # These are the database plugins we support; list is intentionally
 # enum here, as dynamically adding them isn't priority (for now)
-class Plugin(str, Enum):
+class Plugin(StrEnum):
     cassandra = "cassandra"
     clickhouse = "clickhouse"
     files = "files"
@@ -177,7 +178,7 @@ class SnapshotClearRequest(NodeRequest):
 # node.cassandra
 
 
-class CassandraSubOp(str, Enum):
+class CassandraSubOp(StrEnum):
     get_schema_hash = "get-schema-hash"
     remove_snapshot = "remove-snapshot"
     restore_snapshot = "restore-snapshot"

--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -10,7 +10,6 @@ from .magic import StrEnum
 from .progress import Progress
 from .utils import AstacusModel, now, SizeLimitedFile
 from datetime import datetime
-from enum import Enum
 from pathlib import Path
 from pydantic import Field, root_validator
 from typing import List, Optional, Sequence
@@ -56,7 +55,7 @@ class NodeResult(AstacusModel):
 
 class MetadataResult(AstacusModel):
     version: str
-    features: Sequence[str] = Field(default=list)
+    features: Sequence[str] = Field(default=list)  # type: ignore
 
 
 # node.snapshot

--- a/astacus/common/magic.py
+++ b/astacus/common/magic.py
@@ -13,13 +13,18 @@ ASTACUS_TMPDIR = ".astacus"
 EMBEDDED_FILE_SIZE = 200
 
 
-class LockCall(str, Enum):
+class StrEnum(str, Enum):
+    def __str__(self) -> str:
+        return str(self.value)
+
+
+class LockCall(StrEnum):
     lock = "lock"
     relock = "relock"
     unlock = "unlock"
 
 
-class ErrorCode(str, Enum):
+class ErrorCode(StrEnum):
     cluster_lock_unavailable = "cluster_lock_unavailable"
     operation_id_mismatch = "operation_id_mismatch"
 

--- a/astacus/common/rohmustorage.py
+++ b/astacus/common/rohmustorage.py
@@ -7,6 +7,7 @@ Rohmu-specific actual object storage implementation
 
 """
 
+from .magic import StrEnum
 from .storage import MultiStorage, Storage, StorageUploadResult
 from .utils import AstacusModel
 from astacus.common import exceptions
@@ -26,7 +27,7 @@ import tempfile
 logger = logging.getLogger(__name__)
 
 
-class RohmuStorageType(str, Enum):
+class RohmuStorageType(StrEnum):
     """Embodies what is detected in rohmu.get_class_for_transfer"""
 
     azure = "azure"
@@ -44,7 +45,7 @@ class RohmuModel(AstacusModel):
         use_enum_values = True
 
 
-class RohmuProxyType(str, Enum):
+class RohmuProxyType(StrEnum):
     socks5 = "socks5"
     http = "http"
 

--- a/astacus/common/statsd.py
+++ b/astacus/common/statsd.py
@@ -14,6 +14,7 @@ This is combination of:
 - pydantic configuration + async_timing_manager + explicit typing
 
 """
+from .magic import StrEnum
 from .utils import AstacusModel
 from contextlib import asynccontextmanager, contextmanager
 from enum import Enum
@@ -23,7 +24,7 @@ import socket
 import time
 
 
-class MessageFormat(str, Enum):
+class MessageFormat(StrEnum):
     datadog = "datadog"
     telegraf = "telegraf"
 

--- a/astacus/common/statsd.py
+++ b/astacus/common/statsd.py
@@ -17,7 +17,6 @@ This is combination of:
 from .magic import StrEnum
 from .utils import AstacusModel
 from contextlib import asynccontextmanager, contextmanager
-from enum import Enum
 from typing import Optional, Union
 
 import socket

--- a/astacus/config.py
+++ b/astacus/config.py
@@ -8,12 +8,12 @@ Root-level astacus configuration, which includes
 - node configuration
 """
 from astacus.common import magic
+from astacus.common.magic import StrEnum
 from astacus.common.rohmustorage import RohmuConfig
 from astacus.common.statsd import StatsdConfig
 from astacus.common.utils import AstacusModel
 from astacus.coordinator.config import APP_KEY as COORDINATOR_CONFIG_KEY, CoordinatorConfig
 from astacus.node.config import APP_KEY as NODE_CONFIG_KEY, NodeConfig
-from enum import Enum
 from fastapi import FastAPI, Request
 from pathlib import Path
 from typing import Optional, Tuple, Union
@@ -27,7 +27,7 @@ APP_HASH_KEY = "global_config_hash"
 
 
 class UvicornConfig(AstacusModel):
-    class HTTPMode(str, Enum):
+    class HTTPMode(StrEnum):
         auto = "auto"  # default, but sometimes leads to httptools
         h11 = "h11"
         httptools = "httptools"  # crashy on Fedora 31 at least

--- a/astacus/coordinator/api.py
+++ b/astacus/coordinator/api.py
@@ -10,10 +10,10 @@ from .lockops import LockOps
 from .state import CachedListResponse
 from astacus import config
 from astacus.common import ipc
+from astacus.common.magic import StrEnum
 from astacus.common.op import Op
 from astacus.config import APP_HASH_KEY, get_config_content_and_hash
 from asyncio import to_thread
-from enum import Enum
 from fastapi import APIRouter, Depends, HTTPException, Request
 from urllib.parse import urljoin
 
@@ -26,7 +26,7 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-class OpName(str, Enum):
+class OpName(StrEnum):
     """(Long-running) operations defined in this API (for coordinator)"""
 
     backup = "backup"

--- a/astacus/node/api.py
+++ b/astacus/node/api.py
@@ -11,6 +11,7 @@ from .state import node_state, NodeState
 from astacus.common import ipc
 from astacus.common.magic import StrEnum
 from astacus.version import __version__
+from enum import Enum
 from fastapi import APIRouter, Depends, HTTPException
 from typing import Union
 

--- a/astacus/node/api.py
+++ b/astacus/node/api.py
@@ -9,15 +9,15 @@ from .node import Node
 from .snapshot import SnapshotOp, UploadOp
 from .state import node_state, NodeState
 from astacus.common import ipc
+from astacus.common.magic import StrEnum
 from astacus.version import __version__
-from enum import Enum
 from fastapi import APIRouter, Depends, HTTPException
 from typing import Union
 
 router = APIRouter()
 
 
-class OpName(str, Enum):
+class OpName(StrEnum):
     """(Long-running) operations defined in this API (for node)"""
 
     cassandra = "cassandra"

--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -2,7 +2,7 @@
 pre-commit>=2.20.0
 
 # pre-commit tasks in Makefile need these
-anyio==3.3.1
+anyio==3.5.0
 pylint==2.15.5
 pytest-asyncio==0.14.0
 pytest-cov==3.0.0
@@ -10,18 +10,14 @@ pytest-mock==3.3.1
 pytest-order==1.0.0
 pytest-timeout==1.4.2
 pytest-watch==4.2.0
-pytest==6.2.4
+pytest==6.2.5
 
 # pinning mypy to the same version as pre-commit
-mypy==0.910
+mypy==0.991
 # types for things that don't seem to have them
 types-PyYAML>=6.0.12.2
-types-requests>=2.28.11.5
 types-tabulate>=0.9.0.0
 types-urllib3>=1.26.25.4
-typing_extensions>=3.10.0
+typing_extensions>=4.4.0
 
-# fastapi testclient needs this yet does not depend on it, gnn
-requests>=2.28.1
-
-respx==0.16.3
+respx==0.20.1

--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -13,7 +13,7 @@ pytest-watch==4.2.0
 pytest==6.2.5
 
 # pinning mypy to the same version as pre-commit
-mypy==0.991
+mypy==1.0.0
 # types for things that don't seem to have them
 types-PyYAML>=6.0.12.2
 types-tabulate>=0.9.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,16 +10,16 @@ zip_safe = False
 # SKIP-IN-RPM
 install_requires =
   PyYAML==6.0
-  fastapi==0.70.1
-  httpx==0.17.1
-  protobuf==3.14.0
+  fastapi==0.86.0
+  httpx==0.22.0
+  protobuf==3.19.4
   rohmu==1.0.7
   sentry-sdk==1.6.0
-  tabulate==0.8.10
-  typing-extensions==3.10.0
+  tabulate==0.9.0
+  typing-extensions==4.4.0
   uvicorn==0.15.0
   # Pinned transitive deps
-  pydantic==1.7.4
+  pydantic==1.10.2
 
   # Clickhouse support
   kazoo==2.8.0

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ def _run():
             "License :: OSI Approved :: Apache Software License",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
             "Topic :: Database :: Database Engines/Servers",
             "Topic :: Software Development :: Libraries",
         ],


### PR DESCRIPTION
This is a follow up of #93 focusing on test suite breakage ensuing the fastapi requirement update.