### PR TITLE
Fix backup size computation in the presence of duplicate snapshot files

### DIFF
--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -125,7 +125,10 @@ class SnapshotResult(NodeResult):
     start: datetime = Field(default_factory=now)
     end: Optional[datetime]
 
-    # should be passed opaquely to restore
+    # The state is optional because it's written by the Snapshotter post-initialization.
+    # If the backup failed, the related manifest doesn't exist: the state and the
+    # summary attributes below will be set to none and their default values respectively.
+    # Should be passed opaquely to restore.
     state: Optional[SnapshotState] = Field(default_factory=SnapshotState)
 
     # Summary data for manifest use
@@ -259,6 +262,11 @@ class ListSingleBackup(AstacusModel):
     total_size: int
     upload_size: int
     upload_stored_size: int
+    # Number of cluster files and total cluster data size
+    # The two fields are computed from deduplicated files across nodes but not within nodes,
+    # using the files' hexdigest as key. As such, they are *not* sourced from BackupManifest.
+    cluster_files: int
+    cluster_data_size: int
 
 
 class ListForStorage(AstacusModel):

--- a/astacus/coordinator/list.py
+++ b/astacus/coordinator/list.py
@@ -3,12 +3,38 @@ Copyright (c) 2020 Aiven Ltd
 See LICENSE for details
 
 """
-
 from astacus.common import ipc, magic
-from astacus.common.storage import MultiStorage
+from astacus.common.storage import JsonStorage, MultiStorage
+from collections import defaultdict
+from collections.abc import Iterator
 
 
-def _iter_backups(storage):
+def compute_deduplicated_snapshot_file_stats(manifest: ipc.BackupManifest) -> tuple[int, int]:
+    """Compute stats over snapshot files as identified by their hex digest.
+
+    There may be duplicate hex digests within nodes for multiple copies of the same data chunks.
+    Duplicates' size are aggregated as they require physical disk space during restore.
+    On the other hand, hex digests can be safely deduplicated across nodes. The ocurrence with
+    the highest associated file count is kept, giving an upper bound for the cluster data size.
+    """
+    hexdigest_max_counts: dict[str, int] = {}
+    hexdigest_sizes: dict[str, int] = {}
+    for snapshot_result in manifest.snapshot_results:
+        assert snapshot_result.state is not None
+        node_hexdigest_counter: defaultdict[str, int] = defaultdict(lambda: 0)
+        for snapshot_file in snapshot_result.state.files:
+            node_hexdigest_counter[snapshot_file.hexdigest] += 1
+            if snapshot_file.hexdigest not in hexdigest_sizes:
+                hexdigest_sizes[snapshot_file.hexdigest] = snapshot_file.file_size
+        for hexdigest, count in node_hexdigest_counter.items():
+            max_count = hexdigest_max_counts.get(hexdigest, 0)
+            hexdigest_max_counts[hexdigest] = max(max_count, count)
+    num_files = sum(hexdigest_max_counts.values())
+    total_size = sum(count * hexdigest_sizes[hexdigest] for hexdigest, count in hexdigest_max_counts.items())
+    return num_files, total_size
+
+
+def _iter_backups(storage: JsonStorage) -> Iterator[ipc.ListSingleBackup]:
     for name in sorted(storage.list_jsons()):
         if not name.startswith(magic.JSON_BACKUP_PREFIX):
             continue
@@ -18,6 +44,7 @@ def _iter_backups(storage):
         total_size = sum(x.total_size for x in manifest.snapshot_results)
         upload_size = sum(x.total_size for x in manifest.upload_results)
         upload_stored_size = sum(x.total_stored_size for x in manifest.upload_results)
+        cluster_files, cluster_data_size = compute_deduplicated_snapshot_file_stats(manifest)
         yield ipc.ListSingleBackup(
             name=pname,
             start=manifest.start,
@@ -26,13 +53,15 @@ def _iter_backups(storage):
             attempt=manifest.attempt,
             nodes=len(manifest.snapshot_results),
             files=files,
+            cluster_files=cluster_files,
             total_size=total_size,
+            cluster_data_size=cluster_data_size,
             upload_size=upload_size,
             upload_stored_size=upload_stored_size,
         )
 
 
-def _iter_storages(req, json_mstorage):
+def _iter_storages(req: ipc.ListRequest, json_mstorage: MultiStorage) -> Iterator[ipc.ListForStorage]:
     # req.storage is optional, used to constrain listing just to the
     # given storage. by default, we list all storages.
     for storage_name in sorted(json_mstorage.list_storages()):

--- a/tests/unit/coordinator/conftest.py
+++ b/tests/unit/coordinator/conftest.py
@@ -28,7 +28,7 @@ def fixture_mstorage(tmpdir):
 
 
 @pytest.fixture(name="populated_mstorage")
-def fixture_populated_mstorage(mstorage):
+def fixture_populated_mstorage(mstorage: MultiRohmuStorage) -> MultiRohmuStorage:
     x = mstorage.get_storage("x")
     x.upload_json("backup-1", BACKUP_MANIFEST)
     x.upload_json("backup-2", BACKUP_MANIFEST)

--- a/tests/unit/coordinator/test_list.py
+++ b/tests/unit/coordinator/test_list.py
@@ -4,10 +4,32 @@ See LICENSE for details
 
 Test that the list endpoint behaves as advertised
 """
+from astacus.common.ipc import (
+    BackupManifest,
+    ListForStorage,
+    ListRequest,
+    ListResponse,
+    ListSingleBackup,
+    Plugin,
+    SnapshotFile,
+    SnapshotHash,
+    SnapshotResult,
+    SnapshotState,
+    SnapshotUploadResult,
+)
+from astacus.common.rohmustorage import MultiRohmuStorage
 from astacus.coordinator import api
+from astacus.coordinator.list import compute_deduplicated_snapshot_file_stats, list_backups
+from fastapi.testclient import TestClient
+from os import PathLike
+from pathlib import Path
+from tests.utils import create_rohmu_config
+
+import datetime
+import pytest
 
 
-def test_api_list(client, populated_mstorage, mocker):
+def test_api_list(client: TestClient, populated_mstorage: MultiRohmuStorage, mocker) -> None:
     assert populated_mstorage
 
     def _run():
@@ -26,6 +48,8 @@ def test_api_list(client, populated_mstorage, mocker):
                             "name": "1",
                             "plugin": "files",
                             "start": "2020-01-01T21:43:00+00:00",
+                            "cluster_files": 1,
+                            "cluster_data_size": 6,
                             "total_size": 6,
                             "upload_size": 6,
                             "upload_stored_size": 10,
@@ -38,6 +62,8 @@ def test_api_list(client, populated_mstorage, mocker):
                             "name": "2",
                             "plugin": "files",
                             "start": "2020-01-01T21:43:00+00:00",
+                            "cluster_files": 1,
+                            "cluster_data_size": 6,
                             "total_size": 6,
                             "upload_size": 6,
                             "upload_stored_size": 10,
@@ -55,6 +81,8 @@ def test_api_list(client, populated_mstorage, mocker):
                             "name": "3",
                             "plugin": "files",
                             "start": "2020-01-01T21:43:00+00:00",
+                            "cluster_files": 1,
+                            "cluster_data_size": 6,
                             "total_size": 6,
                             "upload_size": 6,
                             "upload_stored_size": 10,
@@ -71,3 +99,157 @@ def test_api_list(client, populated_mstorage, mocker):
     m = mocker.patch.object(api, "list_backups")
     _run()
     assert not m.called
+
+
+@pytest.fixture(name="backup_manifest")
+def fixture_backup_manifest() -> BackupManifest:
+    """Provide a backup manifest with duplicate snapshot files.
+
+    The test snapshot result has five unique snapshot files out of eight.
+    The hexdigest is faked as the table UUID's last digit and a summary of the part name.
+    """
+    return BackupManifest(
+        start=datetime.datetime(2020, 1, 2, 3, 4, 5, 678, tzinfo=datetime.timezone.utc),
+        end=datetime.datetime(2020, 1, 2, 5, 6, 7, 891, tzinfo=datetime.timezone.utc),
+        attempt=1,
+        snapshot_results=[
+            # First node
+            SnapshotResult(
+                state=SnapshotState(
+                    root_globs=[],
+                    files=[
+                        # First table
+                        SnapshotFile(
+                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000001/detached/all_0_0_0/data.bin"),
+                            file_size=1000,
+                            mtime_ns=0,
+                            hexdigest="1000",
+                        ),
+                        SnapshotFile(
+                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000001/detached/all_1_1_0/data.bin"),
+                            file_size=1000,
+                            mtime_ns=0,
+                            hexdigest="1110",
+                        ),
+                        SnapshotFile(
+                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000001/detached/all_1_0_0/data.bin"),
+                            file_size=1000,
+                            mtime_ns=0,
+                            hexdigest="1100",
+                        ),
+                        # Second table
+                        SnapshotFile(
+                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000002/detached/all_0_0_0/data.bin"),
+                            file_size=1000,
+                            mtime_ns=0,
+                            hexdigest="2000",
+                        ),
+                    ],
+                ),
+                hashes=[
+                    SnapshotHash(hexdigest="1000", size=1000),
+                    SnapshotHash(hexdigest="1110", size=1000),
+                    SnapshotHash(hexdigest="1100", size=1000),
+                    SnapshotHash(hexdigest="2000", size=1000),
+                ],
+                files=4,
+                total_size=4000,
+            ),
+            # Second node
+            SnapshotResult(
+                state=SnapshotState(
+                    root_globs=[],
+                    files=[
+                        # First table
+                        SnapshotFile(
+                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000001/detached/all_0_0_0/data.bin"),
+                            file_size=1000,
+                            mtime_ns=0,
+                            hexdigest="1000",
+                        ),
+                        SnapshotFile(
+                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000001/detached/all_1_1_0/data.bin"),
+                            file_size=1000,
+                            mtime_ns=0,
+                            hexdigest="1110",
+                        ),
+                        # Second table
+                        SnapshotFile(
+                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000002/detached/all_0_0_0/data.bin"),
+                            file_size=1000,
+                            mtime_ns=0,
+                            hexdigest="2000",
+                        ),
+                        SnapshotFile(
+                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000002/detached/all_1_1_0/data.bin"),
+                            file_size=1000,
+                            mtime_ns=0,
+                            hexdigest="2110",
+                        ),
+                        # Third table with same hexdigest as second one
+                        SnapshotFile(
+                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000003/detached/all_0_0_0/data.bin"),
+                            file_size=1000,
+                            mtime_ns=0,
+                            hexdigest="2000",
+                        ),
+                    ],
+                ),
+                hashes=[
+                    SnapshotHash(hexdigest="1000", size=1000),
+                    SnapshotHash(hexdigest="1110", size=1000),
+                    SnapshotHash(hexdigest="2000", size=1000),
+                    SnapshotHash(hexdigest="2110", size=1000),
+                    SnapshotHash(hexdigest="2000", size=1000),
+                ],
+                files=5,
+                total_size=5000,
+            ),
+        ],
+        upload_results=[
+            SnapshotUploadResult(total_size=4000, total_stored_size=3000),
+            SnapshotUploadResult(total_size=5000, total_stored_size=4000),
+        ],
+        plugin=Plugin.clickhouse,
+    )
+
+
+def test_compute_deduplicated_snapshot_file_stats(backup_manifest: BackupManifest) -> None:
+    """Test backup stats are computed correctly in the presence of duplicate snapshot files."""
+    num_files, total_size = compute_deduplicated_snapshot_file_stats(backup_manifest)
+    assert (num_files, total_size) == (6, 6000)
+
+
+def test_api_list_deduplication(backup_manifest: BackupManifest, tmpdir: PathLike) -> None:
+    """Test the list backup operation correctly deduplicates snapshot files when computing stats."""
+    multi_rohmu_storage = MultiRohmuStorage(config=create_rohmu_config(tmpdir))
+    storage = multi_rohmu_storage.get_storage("x")
+    storage.upload_json("backup-1", backup_manifest)
+    storage.upload_hexdigest_bytes("FAKEDIGEST", b"fake-digest-data")
+
+    list_request = ListRequest(storage="x")
+    list_response = list_backups(req=list_request, json_mstorage=multi_rohmu_storage)
+    expected_response = ListResponse(
+        storages=[
+            ListForStorage(
+                storage_name="x",
+                backups=[
+                    ListSingleBackup(
+                        name="1",
+                        start=datetime.datetime(2020, 1, 2, 3, 4, 5, 678, tzinfo=datetime.timezone.utc),
+                        end=datetime.datetime(2020, 1, 2, 5, 6, 7, 891, tzinfo=datetime.timezone.utc),
+                        plugin="clickhouse",
+                        attempt=1,
+                        nodes=2,
+                        cluster_files=6,
+                        cluster_data_size=6000,
+                        files=9,
+                        total_size=9000,
+                        upload_size=9000,
+                        upload_stored_size=7000,
+                    )
+                ],
+            ),
+        ]
+    )
+    assert list_response == expected_response


### PR DESCRIPTION
When multiple nodes snapshot files with the same digest, the list operation sums their size incorrectly when returning the corresponding backup's size. 

Deduplicate the snapshot files by hexdigest, and retain the previous behaviour if the backup manifest has no associated snapshot state.