### PR TITLE
Reduce the amount of checksuming for ClickHouse

### DIFF
--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -120,6 +120,15 @@ class SnapshotUploadRequest(NodeRequest):
     storage: str
 
 
+# Added on 2022-11-29, the previous version should be removable after 1 or 2 years.
+class SnapshotUploadRequestV20221129(SnapshotUploadRequest):
+    # Whether we should check if the file hash has changed since the snapshot
+    # Should be False only for plugins where the database is known to never
+    # change the files that we are reading: for instance because the database
+    # itself created a snapshot and Astacus is reading from that snapshot.
+    validate_file_hashes: bool = True
+
+
 class SnapshotUploadResult(NodeResult):
     total_size: int = 0
     total_stored_size: int = 0

--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from pydantic import Field, root_validator
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 import functools
 import socket
@@ -51,6 +51,11 @@ class NodeResult(AstacusModel):
     hostname: str = Field(default_factory=socket.gethostname)
     az: str = ""
     progress: Progress = Field(default_factory=Progress)
+
+
+class MetadataResult(AstacusModel):
+    version: str
+    features: Sequence[str] = Field(default=list)
 
 
 # node.snapshot

--- a/astacus/common/magic.py
+++ b/astacus/common/magic.py
@@ -10,7 +10,7 @@ ASTACUS_DEFAULT_PORT = 5515  # random port not assigned by IANA
 ASTACUS_TMPDIR = ".astacus"
 
 # Hexdigest is 32 bytes, so something orders of magnitude more at least
-EMBEDDED_FILE_SIZE = 100
+EMBEDDED_FILE_SIZE = 200
 
 
 class LockCall(str, Enum):

--- a/astacus/coordinator/plugins/clickhouse/plugin.py
+++ b/astacus/coordinator/plugins/clickhouse/plugin.py
@@ -76,7 +76,7 @@ class ClickHousePlugin(CoordinatorPlugin):
             # Then snapshot and backup all frozen table parts
             SnapshotStep(snapshot_root_globs=[get_frozen_parts_pattern(self.freeze_name)]),
             ListHexdigestsStep(hexdigest_storage=context.hexdigest_storage),
-            UploadBlocksStep(storage_name=context.storage_name),
+            UploadBlocksStep(storage_name=context.storage_name, validate_file_hashes=False),
             # Cleanup frozen parts
             UnfreezeTablesStep(clients=clickhouse_clients, freeze_name=self.freeze_name),
             # Prepare the manifest for restore

--- a/astacus/node/api.py
+++ b/astacus/node/api.py
@@ -28,7 +28,8 @@ class OpName(str, Enum):
 
 
 class Features(Enum):
-    pass
+    # Added on 2022-11-29, this can be assumed to be supported everywhere after 1 or 2 years
+    validate_file_hashes = "validate_file_hashes"
 
 
 @router.get("/metadata")
@@ -84,7 +85,7 @@ def snapshot_result(*, op_id: int, n: Node = Depends()):
 
 
 @router.post("/upload")
-def upload(req: ipc.SnapshotUploadRequest, n: Node = Depends()):
+def upload(req: ipc.SnapshotUploadRequestV20221129, n: Node = Depends()):
     if not n.state.is_locked:
         raise HTTPException(status_code=409, detail="Not locked")
     return UploadOp(n=n, op_id=n.allocate_op_id(), stats=n.stats).start(req=req)

--- a/astacus/node/api.py
+++ b/astacus/node/api.py
@@ -9,6 +9,7 @@ from .node import Node
 from .snapshot import SnapshotOp, UploadOp
 from .state import node_state, NodeState
 from astacus.common import ipc
+from astacus.version import __version__
 from enum import Enum
 from fastapi import APIRouter, Depends, HTTPException
 from typing import Union
@@ -24,6 +25,18 @@ class OpName(str, Enum):
     download = "download"
     snapshot = "snapshot"
     upload = "upload"
+
+
+class Features(Enum):
+    pass
+
+
+@router.get("/metadata")
+def metadata() -> ipc.MetadataResult:
+    return ipc.MetadataResult(
+        version=__version__,
+        features=[feature.value for feature in Features],
+    )
 
 
 @router.post("/lock")

--- a/astacus/node/snapshot.py
+++ b/astacus/node/snapshot.py
@@ -74,5 +74,6 @@ class UploadOp(NodeOp):
                 parallel=self.config.parallel.uploads,
                 progress=self.result.progress,
                 still_running_callback=self.still_running_callback,
+                validate_file_hashes=self.req.validate_file_hashes,
             )
             self.result.progress.done()

--- a/astacus/server.py
+++ b/astacus/server.py
@@ -43,8 +43,8 @@ def init_app():
     config_path = os.environ.get("ASTACUS_CONFIG")
     assert config_path
     api = FastAPI()
-    api.include_router(coordinator_router, tags=["coordinator"])
     api.include_router(node_router, prefix="/node", tags=["node"])
+    api.include_router(coordinator_router, tags=["coordinator"])
 
     @api.on_event("shutdown")
     async def _shutdown_event():

--- a/tests/unit/coordinator/plugins/test_base.py
+++ b/tests/unit/coordinator/plugins/test_base.py
@@ -3,11 +3,23 @@
 Copyright (c) 2021 Aiven Ltd
 See LICENSE for details
 """
+from astacus.common import ipc
+from astacus.common.op import Op
+from astacus.common.progress import Progress
 from astacus.coordinator.cluster import Cluster
-from astacus.coordinator.plugins.base import Step, StepsContext
+from astacus.coordinator.config import CoordinatorNode
+from astacus.coordinator.plugins.base import ListHexdigestsStep, SnapshotStep, Step, StepsContext, UploadBlocksStep
+from astacus.node.api import Features
+from astacus.node.snapshotter import hash_hexdigest_readable
+from http import HTTPStatus
+from io import BytesIO
+from typing import Sequence
 
 import datetime
+import httpx
+import json
 import pytest
+import respx
 
 
 class DummyStep(Step[int]):
@@ -37,3 +49,63 @@ def test_steps_context_result_can_only_be_set_once():
     context.set_result(DummyStep, 10)
     with pytest.raises(RuntimeError):
         context.set_result(DummyStep, 10)
+
+
+def get_sample_hashes() -> list[ipc.SnapshotHash]:
+    data = b"new_data"
+    hexdigest = hash_hexdigest_readable(BytesIO(data))
+    return [ipc.SnapshotHash(hexdigest=hexdigest, size=len(data))]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "node_features,expected_request",
+    [
+        (
+            [],
+            ipc.SnapshotUploadRequest(result_url="", hashes=get_sample_hashes(), storage="fake"),
+        ),
+        (
+            [Features.validate_file_hashes],
+            ipc.SnapshotUploadRequestV20221129(
+                result_url="", hashes=get_sample_hashes(), storage="fake", validate_file_hashes=True
+            ),
+        ),
+    ],
+    ids=["no_feature", "validate_file_hashes"],
+)
+async def test_upload_step_uses_new_request_if_supported(
+    node_features: Sequence[Features], expected_request: ipc.SnapshotUploadRequest
+) -> None:
+    context = StepsContext()
+    context.set_result(ListHexdigestsStep, {})
+    sample_hashes = get_sample_hashes()
+    context.set_result(
+        SnapshotStep, [ipc.SnapshotResult(hostname="localhost", az="az1", files=1, total_size=2, hashes=sample_hashes)]
+    )
+    upload_step = UploadBlocksStep(storage_name="fake")
+    coordinator_nodes = [CoordinatorNode(url="http://node_1")]
+    cluster = Cluster(nodes=coordinator_nodes)
+    with respx.mock:
+
+        def check_request(request: httpx.Request) -> httpx.Response:
+            payload = json.loads(request.content)
+            assert payload == expected_request.jsondict()
+            return httpx.Response(
+                status_code=HTTPStatus.OK, json=Op.StartResult(op_id=1, status_url="http://node_1/upload/1").jsondict()
+            )
+
+        respx.get("http://node_1/metadata").respond(
+            json=ipc.MetadataResult(version="0.1", features=[feature.value for feature in node_features]).jsondict()
+        )
+        respx.post("http://node_1/upload").mock(side_effect=check_request)
+        respx.get("http://node_1/upload/1").respond(
+            json=ipc.SnapshotUploadResult(
+                hostname="localhost",
+                az="az1",
+                progress=Progress(handled=1, total=1, final=True),
+                total_size=10,
+                total_stored_size=8,
+            ).jsondict()
+        )
+        await upload_step.run_step(cluster=cluster, context=context)

--- a/tests/unit/node/test_node_snapshot.py
+++ b/tests/unit/node/test_node_snapshot.py
@@ -31,7 +31,7 @@ def test_snapshot(snapshotter, uploader):
         hashes = snapshotter.get_snapshot_hashes()
         assert len(hashes) == 1
         assert hashes == [
-            ipc.SnapshotHash(hexdigest="326827fe6fd23503bf16eed91861766df522748794814a1bf46d479d9feae1a0", size=600)
+            ipc.SnapshotHash(hexdigest="72f4e28aa8b614a3525309004d2a2281f04d5081141bdf12dc14bc3706f62c8c", size=1200)
         ]
 
         while True:


### PR DESCRIPTION
ClickHouse databases are quite large, hashing each file 3 times for each upload
consumes a significant amount of CPU time (and probably does not help the
IO cache).

Since ClickHouse files never change, only hash them during the snapshot and
not again before and after each upload.

Also increase the threshold for embedded files from 100 to 200 bytes, it's still
small but it helps to include many small ClickHouse files that are exactly
185 bytes (the checksums.txt file present for each table part).

We're adding a new flag to the `/node/upload` API, this would completely fail
on existing nodes, to deal with that, add a `/node/metadata` API that list the
node version and supported features.

For backward compatibility, assume a node not replying to that endpoint has
no feature.