### PR TITLE
clickhouse: allow restoring tables requiring global settings

### DIFF
--- a/tests/integration/coordinator/plugins/clickhouse/test_client.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_client.py
@@ -70,3 +70,13 @@ async def test_client_execute_timeout_can_be_customized_per_query(clickhouse: Se
         await client.execute(b"SELECT 1,sleepEachRow(3)", timeout=1)
     elapsed_time = time.monotonic() - start_time
     assert 1.0 <= elapsed_time < 3.0
+
+
+@pytest.mark.asyncio
+async def test_client_execute_error_returns_status_and_exception_code(clickhouse: Service) -> None:
+    unknown_table_exception_code = 60
+    client = get_clickhouse_client(clickhouse)
+    with pytest.raises(ClickHouseClientQueryError) as raised:
+        await client.execute(b"SELECT * FROM default.does_not_exist", timeout=1)
+    assert raised.value.status_code == 404
+    assert raised.value.exception_code == unknown_table_exception_code

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -733,6 +733,9 @@ async def test_creates_all_replicated_databases_and_tables_in_manifest() -> None
         b"SET receive_timeout=10.0",
         b"CREATE DATABASE `db-two` UUID '00000000-0000-0000-0000-000000000012'"
         b" ENGINE = Replicated('/clickhouse/databases/db%2Dtwo', '{my_shard}', '{my_replica}')",
+        b"SET allow_experimental_geo_types=true",
+        b"SET allow_experimental_object_type=true",
+        b"SET allow_suspicious_low_cardinality_types=true",
         b"CREATE TABLE db-one.table-uno ...",
         b"CREATE TABLE db-one.table-dos ...",
         b"CREATE TABLE db-two.table-eins ...",
@@ -786,6 +789,9 @@ async def test_creates_all_replicated_databases_and_tables_in_manifest_with_cust
         b"CREATE DATABASE `db-two` UUID '00000000-0000-0000-0000-000000000012'"
         b" ENGINE = Replicated('/clickhouse/databases/db%2Dtwo', '{my_shard}', '{my_replica}') "
         b"SETTINGS cluster_username='alice', cluster_password='alice_secret'",
+        b"SET allow_experimental_geo_types=true",
+        b"SET allow_experimental_object_type=true",
+        b"SET allow_suspicious_low_cardinality_types=true",
         b"CREATE TABLE db-one.table-uno ...",
         b"CREATE TABLE db-one.table-dos ...",
         b"CREATE TABLE db-two.table-eins ...",
@@ -831,6 +837,9 @@ async def test_drops_each_database_on_all_servers_before_recreating_it() -> None
         b"SET receive_timeout=10.0",
         b"CREATE DATABASE `db-two` UUID '00000000-0000-0000-0000-000000000012'"
         b" ENGINE = Replicated('/clickhouse/databases/db%2Dtwo', '{my_shard}', '{my_replica}')",
+        b"SET allow_experimental_geo_types=true",
+        b"SET allow_experimental_object_type=true",
+        b"SET allow_suspicious_low_cardinality_types=true",
         b"CREATE TABLE db-one.table-uno ...",
         b"CREATE TABLE db-one.table-dos ...",
         b"CREATE TABLE db-two.table-eins ...",


### PR DESCRIPTION
A table can be created using a transient global settings:
a global settings that was enabled for a single session or a single
query.

For the settings related to experimental features, if we don't
enable them again when recreating the table, the restoration
will fail.

Try to enable those settings before creating all tables:
 - If it's necessary, the table will be restorable.
 - If it's unnecessary, it will be harmless.
 - If it's not allowed, we silently ignore the permission error.

This does not take a stance on whether these settings should be
enabled at all. This decision was already made when the table was
initially created. Astacus merely attempts to recreate what was
already there.