### PR TITLE
cassandra: allow backup/restore of a single datacenter

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,6 +4,7 @@ disable=
     invalid-name,                            # fastapi conventions break this
     missing-docstring,
     no-member,                               # broken with pydantic + inheritance
+    no-self-use,                             # sometimes overriden methods don't use self
     too-few-public-methods,                  # some pydantic models have 0 and it is fine
     too-many-arguments,
     too-many-instance-attributes,            # give me a break, <= 7

--- a/astacus/common/cassandra/schema.py
+++ b/astacus/common/cassandra/schema.py
@@ -229,9 +229,6 @@ class CassandraTable(CassandraNamed):
 
 
 class CassandraKeyspace(CassandraNamed):
-    # CQL to create everything
-    cql_create_all: str
-
     aggregates: List[CassandraAggregate]
     functions: List[CassandraFunction]
     tables: List[CassandraTable]
@@ -244,7 +241,6 @@ class CassandraKeyspace(CassandraNamed):
             name=metadata.name,
             cql_create_self=metadata.as_cql_query(),
             # CassandraKeyspace
-            cql_create_all=metadata.export_as_string(),
             aggregates=sorted(
                 CassandraAggregate.from_cassandra_metadata(metadata) for metadata in metadata.aggregates.values()
             ),

--- a/astacus/common/cassandra/schema.py
+++ b/astacus/common/cassandra/schema.py
@@ -10,7 +10,7 @@ from .client import CassandraSession
 from .utils import is_system_keyspace
 from astacus.common.utils import AstacusModel
 from cassandra import metadata as cm
-from typing import Any, Iterator, List, Set
+from typing import Any, Dict, Iterator, List, Set
 
 import hashlib
 import itertools
@@ -228,7 +228,17 @@ class CassandraTable(CassandraNamed):
                 resource.restore_if_needed(cas, resource_map)
 
 
+def _extract_dcs(metadata: cm.KeyspaceMetadata) -> Dict[str, str]:
+    strategy = metadata.replication_strategy
+    if isinstance(strategy, cm.NetworkTopologyStrategy):
+        return {dc: str(full_replicas) for dc, full_replicas in strategy.dc_replication_factors.items()}
+    return {}
+
+
 class CassandraKeyspace(CassandraNamed):
+    network_topology_strategy_dcs: Dict[str, str]  # not [str, int] because of transient replication
+    durable_writes: bool
+
     aggregates: List[CassandraAggregate]
     functions: List[CassandraFunction]
     tables: List[CassandraTable]
@@ -241,6 +251,8 @@ class CassandraKeyspace(CassandraNamed):
             name=metadata.name,
             cql_create_self=metadata.as_cql_query(),
             # CassandraKeyspace
+            network_topology_strategy_dcs=_extract_dcs(metadata),
+            durable_writes=metadata.durable_writes if metadata.durable_writes is not None else True,
             aggregates=sorted(
                 CassandraAggregate.from_cassandra_metadata(metadata) for metadata in metadata.aggregates.values()
             ),

--- a/astacus/coordinator/plugins/cassandra/plugin.py
+++ b/astacus/coordinator/plugins/cassandra/plugin.py
@@ -49,6 +49,7 @@ class ValidateConfigurationStep(Step[None]):
 class CassandraPlugin(CoordinatorPlugin):
     client: CassandraClientConfiguration
     nodes: Optional[List[CassandraConfigurationNode]]
+    datacenter: Optional[str]
     restore_start_timeout: int = 3600
 
     def get_backup_steps(self, *, context: OperationContext) -> List[Step]:
@@ -65,7 +66,7 @@ class CassandraPlugin(CoordinatorPlugin):
         return [
             ValidateConfigurationStep(nodes=nodes),
             backup_steps.RetrieveSchemaHashStep(),
-            backup_steps.PrepareCassandraManifestStep(client=client, nodes=nodes),
+            backup_steps.PrepareCassandraManifestStep(client=client, nodes=nodes, datacenter=self.datacenter),
             CassandraSubOpStep(op=ipc.CassandraSubOp.remove_snapshot),
             CassandraSubOpStep(op=ipc.CassandraSubOp.take_snapshot),
             backup_steps.AssertSchemaUnchanged(),

--- a/tests/unit/common/cassandra/conftest.py
+++ b/tests/unit/common/cassandra/conftest.py
@@ -1,0 +1,9 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+
+
+from tests.utils import is_cassandra_driver_importable
+
+collect_ignore_glob = [] if is_cassandra_driver_importable() else ["*.py"]

--- a/tests/unit/common/cassandra/test_client.py
+++ b/tests/unit/common/cassandra/test_client.py
@@ -4,8 +4,8 @@ See LICENSE for details
 """
 
 from astacus.common.cassandra.config import CassandraClientConfiguration
-import astacus.common.cassandra.client as client_module
 
+import astacus.common.cassandra.client as client_module
 import pytest
 
 

--- a/tests/unit/common/cassandra/test_client.py
+++ b/tests/unit/common/cassandra/test_client.py
@@ -4,16 +4,12 @@ See LICENSE for details
 """
 
 from astacus.common.cassandra.config import CassandraClientConfiguration
+import astacus.common.cassandra.client as client_module
 
 import pytest
 
 
-@pytest.fixture(name="client_module", scope="session")
-def fixture_client_module():
-    return pytest.importorskip("astacus.common.cassandra.client", reason="Cassandra driver is not available")
-
-
-def test_cassandra_session(client_module, mocker):
+def test_cassandra_session(mocker):
     ccluster = mocker.MagicMock()
     csession = mocker.MagicMock()
     session = client_module.CassandraSession(cluster=ccluster, session=csession)
@@ -36,7 +32,7 @@ second!;
     assert len(csession.execute.mock_calls) == 2
 
 
-def create_client(client_module, mocker, ssl=False):
+def create_client(mocker, ssl=False):
     mocker.patch.object(client_module, "Cluster")
     mocker.patch.object(client_module, "WhiteListRoundRobinPolicy")
 
@@ -51,15 +47,15 @@ def create_client(client_module, mocker, ssl=False):
 
 
 @pytest.mark.parametrize("ssl", [False, True])
-def test_cassandra_client(client_module, mocker, ssl):
-    client: client_module.CassandraClient = create_client(client_module, mocker, ssl=ssl)
+def test_cassandra_client(mocker, ssl):
+    client: client_module.CassandraClient = create_client(mocker, ssl=ssl)
     with client.connect() as session:
         assert isinstance(session, client_module.CassandraSession)
 
 
 @pytest.mark.asyncio
-async def test_cassandra_client_run(client_module, mocker):
-    client = create_client(client_module, mocker)
+async def test_cassandra_client_run(mocker):
+    client = create_client(mocker)
 
     def test_fun(cas):
         return 42

--- a/tests/unit/common/cassandra/test_restore_steps.py
+++ b/tests/unit/common/cassandra/test_restore_steps.py
@@ -1,0 +1,8 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+
+
+def test_parse_plugin_manifest_rewrites_keyspace_datacenters() -> None:
+    pass

--- a/tests/unit/common/cassandra/test_restore_steps.py
+++ b/tests/unit/common/cassandra/test_restore_steps.py
@@ -1,8 +1,0 @@
-"""
-Copyright (c) 2023 Aiven Ltd
-See LICENSE for details
-"""
-
-
-def test_parse_plugin_manifest_rewrites_keyspace_datacenters() -> None:
-    pass

--- a/tests/unit/common/cassandra/test_schema.py
+++ b/tests/unit/common/cassandra/test_schema.py
@@ -3,18 +3,14 @@ Copyright (c) 2022 Aiven Ltd
 See LICENSE for details
 """
 
+from astacus.common.cassandra import schema
+
 import pytest
 
 # pylint: disable=protected-access
 
 
-@pytest.fixture(name="schema", scope="session")
-def fixture_schema():
-    return pytest.importorskip("astacus.common.cassandra.schema", reason="Cassandra driver is not available")
-
-
-def test_schema(schema, mocker):
-
+def test_schema(mocker):
     cut = schema.CassandraUserType(name="cut", cql_create_self="CREATE-USER-TYPE", field_types=["type1", "type2"])
     cfunction = schema.CassandraFunction(name="cf", cql_create_self="CREATE-FUNCTION", argument_types=["atype1", "atype2"])
 
@@ -65,7 +61,7 @@ def test_schema(schema, mocker):
     cs.restore_post_data(cas)
 
 
-def test_schema_keyspace_iterate_user_types_in_restore_order(schema):
+def test_schema_keyspace_iterate_user_types_in_restore_order():
     ut1 = schema.CassandraUserType(name="ut1", cql_create_self="", field_types=[])
     ut2 = schema.CassandraUserType(name="ut2", cql_create_self="", field_types=["ut3", "map<str,frozen<ut1>>"])
     ut3 = schema.CassandraUserType(name="ut3", cql_create_self="", field_types=["ut4"])
@@ -98,6 +94,6 @@ def test_schema_keyspace_iterate_user_types_in_restore_order(schema):
         ('"q""u""o""t""e""d"', ['q"u"o"t"e"d']),
     ],
 )
-def test_iterate_identifiers_in_cql_type_definition(schema, definition, identifiers):
+def test_iterate_identifiers_in_cql_type_definition(definition, identifiers):
     got_identifiers = list(schema._iterate_identifiers_in_cql_type_definition(definition))
     assert got_identifiers == identifiers

--- a/tests/unit/common/cassandra/test_schema.py
+++ b/tests/unit/common/cassandra/test_schema.py
@@ -36,7 +36,6 @@ def test_schema(schema, mocker):
 
     cks = schema.CassandraKeyspace(
         name="cks",
-        cql_create_all="CREATE-KEYSPACE-ALL",
         cql_create_self="CREATE-KEYSPACE",
         aggregates=[cagg],
         functions=[cfunction],
@@ -46,7 +45,6 @@ def test_schema(schema, mocker):
 
     cks_system = schema.CassandraKeyspace(
         name="system",
-        cql_create_all="CREATE-SYSTEM-KEYSPACE-ALL",
         cql_create_self="CREATE-SYSTEM-KEYSPACE",
         aggregates=[],
         functions=[],
@@ -74,7 +72,6 @@ def test_schema_keyspace_iterate_user_types_in_restore_order(schema):
     ut4 = schema.CassandraUserType(name="ut4", cql_create_self="", field_types=["something"])
     ks = schema.CassandraKeyspace(
         name="unused",
-        cql_create_all="unused",
         cql_create_self="unused",
         aggregates=[],
         functions=[],

--- a/tests/unit/coordinator/plugins/cassandra/builders.py
+++ b/tests/unit/coordinator/plugins/cassandra/builders.py
@@ -1,0 +1,30 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+
+from astacus.common.cassandra.schema import CassandraKeyspace
+from typing import Mapping
+
+
+class CassandraKeyspaceBuilder(CassandraKeyspace):
+    def with_cql_create_self(self, cql_create_self: str) -> "CassandraKeyspaceBuilder":
+        self.cql_create_self = cql_create_self
+        return self
+
+    def with_network_topology_strategy_dcs(self, dcs: Mapping[str, str]) -> "CassandraKeyspaceBuilder":
+        self.network_topology_strategy_dcs = dcs
+        return self
+
+
+def build_keyspace(name: str) -> CassandraKeyspaceBuilder:
+    return CassandraKeyspaceBuilder(
+        name=name,
+        cql_create_self="",
+        network_topology_strategy_dcs={},
+        durable_writes=True,
+        aggregates=[],
+        functions=[],
+        tables=[],
+        user_types=[],
+    )

--- a/tests/unit/coordinator/plugins/cassandra/conftest.py
+++ b/tests/unit/coordinator/plugins/cassandra/conftest.py
@@ -1,0 +1,9 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+
+
+from tests.utils import is_cassandra_driver_importable
+
+collect_ignore_glob = [] if is_cassandra_driver_importable() else ["*.py"]

--- a/tests/unit/coordinator/plugins/cassandra/test_backup_steps.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_backup_steps.py
@@ -5,6 +5,9 @@ See LICENSE for details
 
 # pylint: disable=protected-access
 
+from astacus.common.cassandra.schema import CassandraSchema
+from astacus.coordinator.plugins.cassandra import backup_steps
+from astacus.coordinator.plugins.cassandra.model import CassandraConfigurationNode
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Optional
@@ -42,15 +45,7 @@ class RetrieveTestCase:
     ids=str,
 )
 def test_retrieve_manifest_from_cassandra(mocker, case):
-    backup_steps = pytest.importorskip("astacus.coordinator.plugins.cassandra.model.backup_steps")
-    plugin_model = pytest.importorskip("astacus.coordinator.plugins.cassandra.model")
-    cassandra_schema = pytest.importorskip("astacus.common.cassandra.schema")
-    mocker.patch.object(
-        cassandra_schema.CassandraSchema,
-        "from_cassandra_session",
-        return_value=cassandra_schema.CassandraSchema(keyspaces=[]),
-    )
-
+    mocker.patch.object(CassandraSchema, "from_cassandra_session", return_value=CassandraSchema(keyspaces=[]))
     cassandra_nodes = [
         SimpleNamespace(
             host_id=UUID(f"1234567812345678123456781234567{node}"),
@@ -73,7 +68,7 @@ def test_retrieve_manifest_from_cassandra(mocker, case):
 
     nodes = []
     for cassandra_node in cassandra_nodes:
-        cnode = plugin_model.CassandraConfigurationNode()
+        cnode = CassandraConfigurationNode()
         # Note: 'tokens' is bit awkward to to test and unlikely to be really used so not tested here.
         if case.field:
             if case.field == "listen_address":

--- a/tests/unit/coordinator/plugins/cassandra/test_plugin.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_plugin.py
@@ -5,6 +5,7 @@ See LICENSE for details
 
 from astacus.common import ipc
 from astacus.coordinator.plugins.base import StepFailedError
+from astacus.coordinator.plugins.cassandra import plugin
 from tests.unit.node.test_node_cassandra import CassandraTestConfig
 from types import SimpleNamespace
 
@@ -13,14 +14,12 @@ import pytest
 
 @pytest.fixture(name="cplugin")
 def fixture_cplugin(mocker, tmpdir):
-    plugin = pytest.importorskip("astacus.coordinator.plugins.cassandra.plugin")
     ctc = CassandraTestConfig(mocker=mocker, tmpdir=tmpdir)
     yield plugin.CassandraPlugin(client=ctc.cassandra_client_config)
 
 
 @pytest.mark.asyncio
 async def test_step_cassandrasubop(mocker):
-    plugin = pytest.importorskip("astacus.coordinator.plugins.cassandra.plugin")
     mocker.patch.object(plugin, "run_subop")
 
     step = plugin.CassandraSubOpStep(op=ipc.CassandraSubOp.stop_cassandra)
@@ -33,7 +32,6 @@ async def test_step_cassandrasubop(mocker):
 @pytest.mark.parametrize("success", [False, True])
 @pytest.mark.asyncio
 async def test_step_cassandra_validate_configuration(mocker, success):
-    plugin = pytest.importorskip("astacus.coordinator.plugins.cassandra.plugin")
     step = plugin.ValidateConfigurationStep(nodes=[])
     context = None
     if success:

--- a/tests/unit/coordinator/plugins/cassandra/test_restore_steps.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_restore_steps.py
@@ -4,7 +4,10 @@ See LICENSE for details
 """
 
 from astacus.common import ipc
+from astacus.common.cassandra.schema import CassandraSchema
 from astacus.coordinator.plugins import base
+from astacus.coordinator.plugins.cassandra import restore_steps
+from astacus.coordinator.plugins.cassandra.model import CassandraManifest, CassandraManifestNode
 from types import SimpleNamespace
 
 import datetime
@@ -16,16 +19,10 @@ import pytest
 @pytest.mark.parametrize("override_tokens", [False, True])
 @pytest.mark.asyncio
 async def test_step_start_cassandra(mocker, override_tokens):
-    restore_steps = pytest.importorskip("astacus.coordinator.plugins.cassandra.model.restore_steps")
-    cassandra_schema = pytest.importorskip("astacus.common.cassandra.schema")
-    plugin_model = pytest.importorskip("astacus.coordinator.plugins.cassandra.model")
-
-    schema = cassandra_schema.CassandraSchema(keyspaces=[])
-
-    plugin_manifest = plugin_model.CassandraManifest(
-        cassandra_schema=schema,
+    plugin_manifest = CassandraManifest(
+        cassandra_schema=CassandraSchema(keyspaces=[]),
         nodes=[
-            plugin_model.CassandraManifestNode(
+            CassandraManifestNode(
                 address="127.0.0.1",
                 host_id="12345678123456781234567812345678",
                 listen_address="::1",
@@ -78,7 +75,6 @@ class AsyncIterableWrapper:
 @pytest.mark.parametrize("steps,success", [([True], True), ([False, True], True), ([False], False)])
 @pytest.mark.asyncio
 async def test_step_wait_cassandra_up(mocker, steps, success):
-    restore_steps = pytest.importorskip("astacus.coordinator.plugins.cassandra.model.restore_steps")
     get_schema_steps = steps[:]
 
     async def get_schema_hash(cluster):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,7 @@ from astacus.common.rohmustorage import RohmuConfig
 from pathlib import Path
 from typing import List, Sequence, Union
 
+import importlib
 import re
 import subprocess
 
@@ -84,3 +85,7 @@ def parse_clickhouse_version(command_output: bytes) -> Sequence[int]:
 def get_clickhouse_version(command: List[Union[str, Path]]) -> Sequence[int]:
     version_command_output = subprocess.check_output([*command, "--version"])
     return parse_clickhouse_version(version_command_output)
+
+
+def is_cassandra_driver_importable() -> bool:
+    return importlib.util.find_spec("cassandra") is not None


### PR DESCRIPTION
In a multi-datacenter setup, you might want to have separate Astacus
clusters in different datacenter, each managing it's own part of the
cluster (e.g. because your datacenters mirror each other and you want
independent backups in different regions for disaster recovery).
If you configure the datacenter parameter in Cassandra plugin config,
Astacus will ignore nodes from other datacenters when creating a
backup and rewrite the keyspace replication settings accordingly on
backup and restore (setting NetworkTopologyStrategy to replicate
within the datacenter you specified and allowing you to restore a
single region when other datacenters are not available).