### PR TITLE
Raise the level of some of the log messages

### DIFF
--- a/astacus/common/op.py
+++ b/astacus/common/op.py
@@ -66,7 +66,7 @@ class Op:
             return False
         if self.info.op_status == status:
             return False
-        logger.debug("%s.%d status %s -> %s", self.info.op_name, self.info.op_id, self.info.op_status, status)
+        logger.info("%s.%d status %s -> %s", self.info.op_name, self.info.op_id, self.info.op_status, status)
         self.info.op_status = status
         return True
 

--- a/astacus/common/progress.py
+++ b/astacus/common/progress.py
@@ -51,7 +51,7 @@ class Progress(AstacusModel):
     def start(self, n):
         "Optional 'first' step, just for logic handling state (e.g. no progress object reuse desired)"
         assert not self.total
-        logger.debug("start")
+        logger.info("start")
         self.add_total(n)
 
     def add_total(self, n):
@@ -60,7 +60,7 @@ class Progress(AstacusModel):
         old_total = self.total
         self.total += n
         if increase_worth_reporting(old_total, self.total):
-            logger.debug("add_total %r -> %r", n, self)
+            logger.info("add_total %r -> %r", n, self)
         assert not self.final
 
     def add_fail(self, n=1, *, info="add_fail"):
@@ -68,7 +68,7 @@ class Progress(AstacusModel):
         old_failed = self.failed
         self.failed += n
         if increase_worth_reporting(old_failed, self.failed):
-            logger.debug("%s %r -> %r", info, n, self)
+            logger.info("%s %r -> %r", info, n, self)
         assert not self.final
 
     def add_success(self, n=1, *, info="add_success"):
@@ -77,7 +77,7 @@ class Progress(AstacusModel):
         self.handled += n
         assert self.handled <= self.total
         if increase_worth_reporting(old_handled, self.handled, total=self.total):
-            logger.debug("%s %r -> %r", info, n, self)
+            logger.info("%s %r -> %r", info, n, self)
         assert not self.final
 
     def download_success(self, size):
@@ -96,7 +96,7 @@ class Progress(AstacusModel):
         assert self.total is not None and self.handled <= self.total
         assert not self.final
         self.final = True
-        logger.debug("done %r", self)
+        logger.info("done %r", self)
 
     @property
     def finished_successfully(self):

--- a/astacus/common/storage.py
+++ b/astacus/common/storage.py
@@ -119,12 +119,12 @@ class FileStorage(Storage):
 
     @file_error_wrapper
     def delete_hexdigest(self, hexdigest):
-        logger.debug("delete_hexdigest %r", hexdigest)
+        logger.info("delete_hexdigest %r", hexdigest)
         self._hexdigest_to_path(hexdigest).unlink()
 
     def _list(self, suffix):
         results = [p.stem for p in self.path.iterdir() if p.suffix == suffix]
-        logger.debug("_list %s => %d", suffix, len(results))
+        logger.info("_list %s => %d", suffix, len(results))
         return results
 
     def list_hexdigests(self):
@@ -132,13 +132,13 @@ class FileStorage(Storage):
 
     @file_error_wrapper
     def download_hexdigest_to_file(self, hexdigest, f) -> bool:
-        logger.debug("download_hexdigest_to_file %r", hexdigest)
+        logger.info("download_hexdigest_to_file %r", hexdigest)
         path = self._hexdigest_to_path(hexdigest)
         f.write(path.read_bytes())
         return True
 
     def upload_hexdigest_from_file(self, hexdigest, f) -> StorageUploadResult:
-        logger.debug("upload_hexdigest_from_file %r", hexdigest)
+        logger.info("upload_hexdigest_from_file %r", hexdigest)
         path = self._hexdigest_to_path(hexdigest)
         data = f.read()
         path.write_bytes(data)
@@ -146,12 +146,12 @@ class FileStorage(Storage):
 
     @file_error_wrapper
     def delete_json(self, name: str):
-        logger.debug("delete_json %r", name)
+        logger.info("delete_json %r", name)
         self._json_to_path(name).unlink()
 
     @file_error_wrapper
     def download_json(self, name: str):
-        logger.debug("download_json %r", name)
+        logger.info("download_json %r", name)
         path = self._json_to_path(name)
         with open(path) as f:
             return json.load(f)
@@ -160,7 +160,7 @@ class FileStorage(Storage):
         return self._list(self.json_suffix)
 
     def upload_json_str(self, name: str, data: str):
-        logger.debug("upload_json_str %r", name)
+        logger.info("upload_json_str %r", name)
         path = self._json_to_path(name)
         with path.open(mode="w") as f:
             f.write(data)

--- a/astacus/common/utils.py
+++ b/astacus/common/utils.py
@@ -84,7 +84,7 @@ def http_request(url, *, caller, method="get", timeout=10, ignore_status_code: b
     """
     # TBD: may need to redact url in future, if we actually wind up
     # using passwords in urls here.
-    logger.debug("request %s %s by %s", method, url, caller)
+    logger.info("request %s %s by %s", method, url, caller)
     try:
         r = requests.request(method, url, timeout=timeout, **kw)
         if r.ok:
@@ -113,7 +113,7 @@ async def httpx_request(
     r = None
     # TBD: may need to redact url in future, if we actually wind up
     # using passwords in urls here.
-    logger.debug("async-request %s %s by %s", method, url, caller)
+    logger.info("async-request %s %s by %s", method, url, caller)
     async with httpx.AsyncClient() as client:
         try:
             r = await client.request(method, url, timeout=timeout, **kw)
@@ -206,7 +206,7 @@ def exponential_backoff(
                 time_left_after_sleep = (self.initial + duration) - time_now - delay
                 if time_left_after_sleep < 0:
                     return None
-            logger.debug("exponential_backoff waiting %.2f seconds (retry %d%s)", delay, self.retry, retries_text)
+            logger.info("exponential_backoff waiting %.2f seconds (retry %d%s)", delay, self.retry, retries_text)
             return delay
 
         async def __anext__(self):

--- a/astacus/coordinator/cleanup.py
+++ b/astacus/coordinator/cleanup.py
@@ -52,9 +52,9 @@ class CleanupOp(LockedCoordinatorOp):
         await self.delete_dangling_hexdigests()
 
     async def delete_dangling_hexdigests(self):
-        logger.debug("delete_dangling_hexdigests - downloading backup list")
+        logger.info("delete_dangling_hexdigests - downloading backup list")
         backups = await self._list_backups()
-        logger.debug("downloading backup manifests")
+        logger.info("downloading backup manifests")
         manifests = await self._download_backup_manifests(backups)
         kept_hexdigests = set()
         for manifest in manifests:
@@ -66,7 +66,7 @@ class CleanupOp(LockedCoordinatorOp):
         extra_hexdigests = set(all_hexdigests).difference(kept_hexdigests)
         if not extra_hexdigests:
             return
-        logger.debug("deleting %d hexdigests from object storage", len(extra_hexdigests))
+        logger.info("deleting %d hexdigests from object storage", len(extra_hexdigests))
         for i, hexdigest in enumerate(extra_hexdigests, 1):
             # Due to rate limiting, it might be better to not do this in parallel
             await self.context.hexdigest_storage.delete_hexdigest(hexdigest)

--- a/astacus/coordinator/cluster.py
+++ b/astacus/coordinator/cluster.py
@@ -125,7 +125,7 @@ class Cluster:
             nodes=nodes,
             caller="Cluster._request_lock_call_from_nodes",
         )
-        logger.debug("%s results: %r", call, results)
+        logger.info("%s results: %r", call, results)
         if call in [LockCall.lock, LockCall.relock]:
             expected_result = {"locked": True}
         elif call in [LockCall.unlock]:
@@ -217,7 +217,7 @@ class Cluster:
             if not any(True for result in results if result is None or not result.progress.final):
                 break
         else:
-            logger.debug("wait_successful_results timed out")
+            logger.info("wait_successful_results timed out")
             raise WaitResultError("timed out")
         # The case is valid because we get there when all results are not None
         return cast(List[NR], results)

--- a/astacus/coordinator/coordinator.py
+++ b/astacus/coordinator/coordinator.py
@@ -267,7 +267,7 @@ class SteppedCoordinatorOp(LockedCoordinatorOp):
         name = self.__class__.__name__
         try:
             for attempt in range(1, self.attempts + 1):
-                logger.debug("%s - attempt #%d/%d", name, attempt, self.attempts)
+                logger.info("%s - attempt #%d/%d", name, attempt, self.attempts)
                 context = StepsContext(attempt=attempt)
                 stats_tags: Tags = {"op": name, "attempt": str(attempt)}
                 async with self.stats.async_timing_manager("astacus_attempt_duration", stats_tags):
@@ -287,7 +287,7 @@ class SteppedCoordinatorOp(LockedCoordinatorOp):
             if self.state.shutting_down:
                 logger.info("Step %s not even started due to shutdown", step_name)
                 return False
-            logger.debug("Step %d/%d: %s", i, len(self.steps), step_name)
+            logger.info("Step %d/%d: %s", i, len(self.steps), step_name)
             async with self.stats.async_timing_manager("astacus_step_duration", {"op": op_name, "step": step_name}):
                 with self._progress_handler(cluster, step):
                     try:

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -161,7 +161,7 @@ class UploadManifestStep(Step[None]):
             plugin=self.plugin,
             plugin_data=plugin_data,
         )
-        logger.debug("Storing backup manifest %s", context.backup_name)
+        logger.info("Storing backup manifest %s", context.backup_name)
         await self.json_storage.upload_json(context.backup_name, manifest)
 
 
@@ -402,7 +402,7 @@ def build_node_index_datas(
 async def upload_node_index_datas(
     cluster: Cluster, storage_name: str, node_index_datas: List[NodeIndexData], validate_file_hashes: bool
 ):
-    logger.debug("upload_node_index_datas")
+    logger.info("upload_node_index_datas")
     start_results: List[Optional[Result]] = []
     nodes_metadata = await get_nodes_metadata(cluster)
     for data in node_index_datas:

--- a/astacus/coordinator/plugins/m3db.py
+++ b/astacus/coordinator/plugins/m3db.py
@@ -134,7 +134,7 @@ class RewriteEtcdStep(Step[Optional[ETCDDump]]):
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> Optional[ETCDDump]:
         if self.partial_restore_nodes:
-            logger.debug("Skipping etcd rewrite due to partial backup restoration")
+            logger.info("Skipping etcd rewrite due to partial backup restoration")
             return None
         backup_manifest = context.get_result(BackupManifestStep)
         node_to_backup_index = get_node_to_backup_index(
@@ -165,7 +165,7 @@ class RestoreEtcdStep(Step[None]):
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
         if self.partial_restore_nodes:
-            logger.debug("Skipping etcd rewrite due to partial backup restoration")
+            logger.info("Skipping etcd rewrite due to partial backup restoration")
         dump = context.get_result(RewriteEtcdStep)
         if dump is not None:
             if not await restore_etcd_dump(client=self.etcd_client, dump=dump):

--- a/astacus/node/clear.py
+++ b/astacus/node/clear.py
@@ -24,7 +24,7 @@ class ClearOp(NodeOp):
     def start(self, *, req: ipc.SnapshotClearRequest):
         self.req = req
         self.snapshotter = self.get_or_create_snapshotter(req.root_globs)
-        logger.debug("start_clear %r", req)
+        logger.info("start_clear %r", req)
         return self.start_op(op_name="clear", op=self, fun=self.clear)
 
     def clear(self):

--- a/astacus/node/download.py
+++ b/astacus/node/download.py
@@ -118,7 +118,7 @@ class DownloadOp(NodeOp):
     def start(self, *, req: ipc.SnapshotDownloadRequest):
         self.req = req
         self.snapshotter = self.get_or_create_snapshotter(req.root_globs)
-        logger.debug("start_download %r", req)
+        logger.info("start_download %r", req)
         return self.start_op(op_name="download", op=self, fun=self.download)
 
     def download(self):

--- a/astacus/node/snapshot.py
+++ b/astacus/node/snapshot.py
@@ -32,7 +32,7 @@ class SnapshotOp(NodeOp):
 
     def start(self, *, req: ipc.SnapshotRequest):
         self.req = req
-        logger.debug("start_snapshot %r", req)
+        logger.info("start_snapshot %r", req)
         self.snapshotter = self.get_or_create_snapshotter(req.root_globs)
         return self.start_op(op_name="snapshot", op=self, fun=self.snapshot)
 
@@ -59,7 +59,7 @@ class UploadOp(NodeOp):
 
     def start(self, *, req: ipc.SnapshotUploadRequest):
         self.req = req
-        logger.debug("start_upload %r", req)
+        logger.info("start_upload %r", req)
         return self.start_op(op_name="upload", op=self, fun=self.upload)
 
     def upload(self):

--- a/astacus/node/snapshotter.py
+++ b/astacus/node/snapshotter.py
@@ -111,14 +111,14 @@ class Snapshotter:
             except FileNotFoundError:
                 lost += 1
                 if increase_worth_reporting(lost):
-                    logger.debug("#%d. lost - %s disappeared before stat, ignoring", lost, self.src / relative_path)
+                    logger.info("#%d. lost - %s disappeared before stat, ignoring", lost, self.src / relative_path)
                 continue
             if old_snapshotfile and old_snapshotfile.underlying_file_is_the_same(new_snapshotfile):
                 new_snapshotfile.hexdigest = old_snapshotfile.hexdigest
                 new_snapshotfile.content_b64 = old_snapshotfile.content_b64
                 same += 1
                 if increase_worth_reporting(same):
-                    logger.debug("#%d. same - %r in %s is same", same, old_snapshotfile, relative_path)
+                    logger.info("#%d. same - %r in %s is same", same, old_snapshotfile, relative_path)
                 continue
 
             yield new_snapshotfile
@@ -139,7 +139,7 @@ class Snapshotter:
             dst_path = self.dst / relative_dir
             dst_path.mkdir(parents=True, exist_ok=True)
             if increase_worth_reporting(i):
-                logger.debug("#%d. new directory: %r", i, relative_dir)
+                logger.info("#%d. new directory: %r", i, relative_dir)
             changes += 1
         return changes
 
@@ -152,7 +152,7 @@ class Snapshotter:
                 self._remove_snapshotfile(snapshotfile)
             dst_path.unlink()
             if increase_worth_reporting(i):
-                logger.debug("#%d. extra file: %r", i, relative_path)
+                logger.info("#%d. extra file: %r", i, relative_path)
             changes += 1
         return changes
 
@@ -172,15 +172,15 @@ class Snapshotter:
                 # exceptions not handled.
                 existing += 1
                 if increase_worth_reporting(existing):
-                    logger.debug("#%d. %s already existed, ignoring", existing, src_path)
+                    logger.info("#%d. %s already existed, ignoring", existing, src_path)
                 continue
             except FileNotFoundError:
                 disappeared += 1
                 if increase_worth_reporting(disappeared):
-                    logger.debug("#%d. %s disappeared before linking, ignoring", disappeared, src_path)
+                    logger.info("#%d. %s disappeared before linking, ignoring", disappeared, src_path)
                 continue
             if increase_worth_reporting(i - disappeared):
-                logger.debug("#%d. new file: %r", i - disappeared, relative_path)
+                logger.info("#%d. new file: %r", i - disappeared, relative_path)
             changes += 1
         return changes
 

--- a/astacus/node/uploader.py
+++ b/astacus/node/uploader.py
@@ -51,7 +51,7 @@ class Uploader(ThreadLocalStorage):
                         upload_result = storage.upload_hexdigest_from_file(hexdigest, f)
                 except exceptions.TransientException as ex:
                     # Do not pollute logs with transient exceptions
-                    logger.debug("Transient exception uploading %r: %r", path, ex)
+                    logger.info("Transient exception uploading %r: %r", path, ex)
                     return progress.upload_failure, 0, 0
                 except exceptions.AstacusException:
                     # Report failure - whole step will be retried later

--- a/astacus/server.py
+++ b/astacus/server.py
@@ -102,7 +102,7 @@ def _run_server(args) -> bool:
             "formatters": {
                 "default": {
                     "()": "uvicorn.logging.DefaultFormatter",
-                    "fmt": "%(levelprefix)s %(message)s",
+                    "fmt": "%(levelname)s\t%(name)s\t%(message)s",
                     "use_colors": None,
                 },
                 "access": {


### PR DESCRIPTION
Running astacus with a DEBUG log level is very verbose, mainly
because of the underlying libraries for object storage.

But running it with INFO loses a lot of useful information about
backup progress.

Raise the level of some of astacus log messages to make it
more useful to run at INFO level.

Also adjust the log formatting to be able to locate the logging sources.