### PR TITLE
coordinator: expose busy concept

### DIFF
--- a/astacus/coordinator/api.py
+++ b/astacus/coordinator/api.py
@@ -139,3 +139,8 @@ async def op_sub_result(*, op_name: OpName, op_id: int, c: Coordinator = Depends
     if not op.subresult_sleeper:
         return
     op.subresult_sleeper.wakeup()
+
+
+@router.get("/busy")
+async def is_busy(*, c: Coordinator = Depends()) -> bool:
+    return c.is_busy()

--- a/astacus/coordinator/coordinator.py
+++ b/astacus/coordinator/coordinator.py
@@ -7,6 +7,7 @@ from astacus.common import asyncstorage, exceptions, ipc, op, statsd, utils
 from astacus.common.cachingjsonstorage import MultiCachingJsonStorage
 from astacus.common.dependencies import get_request_url
 from astacus.common.magic import ErrorCode
+from astacus.common.op import Op
 from astacus.common.progress import Progress
 from astacus.common.rohmustorage import MultiRohmuStorage
 from astacus.common.statsd import StatsClient, Tags
@@ -93,6 +94,9 @@ class Coordinator(op.OpMixin):
     def get_json_storage(self, storage_name: str) -> asyncstorage.AsyncJsonStorage:
         storage = CacheClearingJsonStorage(state=self.state, storage=self.json_mstorage.get_storage(storage_name))
         return asyncstorage.AsyncJsonStorage(storage)
+
+    def is_busy(self) -> bool:
+        return bool(self.state.op and self.state.op_info.op_status in (Op.Status.running.value, Op.Status.starting.value))
 
 
 class CacheClearingJsonStorage(JsonStorage):

--- a/tests/unit/coordinator/test_busy.py
+++ b/tests/unit/coordinator/test_busy.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 Aiven, Helsinki, Finland. https://aiven.io/
+
+
+from astacus.common.op import Op
+from astacus.common.statsd import StatsClient
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+from tests.unit.common.test_op_stats import DummyOp
+
+import pytest
+
+
+def test_not_busy_if_no_coordinator_state(app: FastAPI, client: TestClient) -> None:
+    app.state.coordinator_state = None
+    assert not client.get("/busy").json()
+
+
+@pytest.mark.parametrize("finished_status", [Op.Status.fail, Op.Status.done])
+def test_not_busy_if_failed_or_done(app: FastAPI, client: TestClient, finished_status: Op.Status) -> None:
+    stats = StatsClient(config=None)
+    operation = DummyOp(info=Op.Info(op_id=1, op_name="DummyOp", op_status=finished_status), op_id=1, stats=stats)
+    app.state.coordinator_state.op = operation
+    app.state.coordinator_state.op_info = operation.info
+    assert not client.get("/busy").json()
+
+
+@pytest.mark.parametrize("finished_status", [Op.Status.running, Op.Status.starting])
+def test_busy_if_starting_or_running(app: FastAPI, client: TestClient, finished_status: Op.Status) -> None:
+    stats = StatsClient(config=None)
+    operation = DummyOp(info=Op.Info(op_id=1, op_name="DummyOp", op_status=finished_status), op_id=1, stats=stats)
+    app.state.coordinator_state.op = operation
+    app.state.coordinator_state.op_info = operation.info
+    assert client.get("/busy").json()

--- a/tests/unit/node/conftest.py
+++ b/tests/unit/node/conftest.py
@@ -18,7 +18,7 @@ import pytest
 
 
 @pytest.fixture(name="app")
-def fixture_app(tmpdir):
+def fixture_app(tmpdir) -> FastAPI:
     app = FastAPI()
     app.include_router(node_router, prefix="/node", tags=["node"])
     root = Path(tmpdir) / "root"
@@ -51,7 +51,7 @@ def fixture_app(tmpdir):
 
 
 @pytest.fixture(name="client")
-def fixture_client(app):
+def fixture_client(app) -> TestClient:
     yield TestClient(app)
 
 


### PR DESCRIPTION
In order to avoid an excessive system load when using both Astacus and
Cashew, we'd like to understand when Astacus is actually doing something
(can happen if prune is restarted).
