### PR TITLE
fix: Exclude tests from exposed modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def _run():
 
     setuptools.setup(
         version=version_for_setup_py,
-        packages=setuptools.find_packages(exclude=["test"]),
+        packages=setuptools.find_packages(exclude=["tests"]),
         extras_require={
             "cassandra": ["cassandra-driver==3.20.2"],
         },


### PR DESCRIPTION
I noticed this while trying to create a sanity check to build confidence that `importlib.metadata.distributions()` returns distributions in same order as used by import tooling. It looks like this typo in setup.py prevents the `tests` package from being excluded.

This can be verified like below, or by noting the presence of `tests/*` in `site-packages/astacus*egg-info/SOURCES.txt`.

```pycon
>>> [pkg for pkg, dists in importlib.metadata.packages_distributions().items() if "astacus" in dists]
['astacus', 'tests']
```

This could be prevented in the future by using a MANIFEST.in file in combination with running [check-manifest](https://github.com/mgedmin/check-manifest) in CI.