### PR TITLE
cassandra: revert client configuration path field type change

### DIFF
--- a/astacus/common/cassandra/config.py
+++ b/astacus/common/cassandra/config.py
@@ -15,9 +15,9 @@ https://github.com/samuelcolvin/pydantic/issues/3376
 
 
 """
-
 from astacus.common.utils import AstacusModel
-from pydantic import FilePath, root_validator
+from pathlib import Path
+from pydantic import root_validator
 from typing import List, Optional
 
 import yaml
@@ -26,7 +26,7 @@ SNAPSHOT_NAME = "astacus-backup"
 
 
 class CassandraClientConfiguration(AstacusModel):
-    config_path: Optional[FilePath]
+    config_path: Optional[Path]
 
     # WhiteListRoundRobinPolicy contact points
     hostnames: Optional[List[str]]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,7 +6,6 @@ from astacus import config
 from fastapi import FastAPI
 from pathlib import Path
 
-import pydantic
 import pytest
 
 EXAMPLE_PATH = Path(config.__file__).parent.parent / "examples"
@@ -32,22 +31,3 @@ def test_config_sample_load(path: Path, tmp_path: Path) -> None:
     conf = conf.replace("/tmp/astacus", str(astacus_dir)).replace("example/cassandra", str(EXAMPLE_PATH / "cassandra"))
     rewritten_conf.write_text(conf, encoding="ascii")
     config.set_global_config_from_path(app, rewritten_conf)
-
-
-@pytest.mark.parametrize("path", list(EXAMPLE_PATH.glob("astacus-cassandra*.yaml")), ids=lambda path: path.name)
-def test_config_load_fails_when_cassandra_config_does_not_exist(path: Path, tmp_path: Path) -> None:
-    astacus_dir = tmp_path / "astacus"
-    astacus_dir.mkdir()
-    (astacus_dir / "backup").mkdir()  # object storage
-    (astacus_dir / "cassandra").mkdir()  # cassandra data
-
-    app = FastAPI()
-    rewritten_conf = tmp_path / "astacus.conf"
-
-    conf = path.read_text()
-    conf = conf.replace("/tmp/astacus", str(astacus_dir))
-    rewritten_conf.write_text(conf, encoding="ascii")
-    with pytest.raises(
-        pydantic.ValidationError, match='file or directory at path "example/cassandra-conf.yaml" does not exist'
-    ):
-        config.set_global_config_from_path(app, rewritten_conf)


### PR DESCRIPTION
Astacus doesn't strictly need to depend on the Cassandra configuration file existing during startup. Backup management commands can be executed succesfully without the client configuration.

This is a partial revert of commit 8ba9255e472083aee643865143fca9d701cc4940