### PR TITLE
 clickhouse: add support for multiple and remote disks 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python 3.10 with caching
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'pip'
 
       - name: Install requirements

--- a/.github/workflows/tests-all.yml
+++ b/.github/workflows/tests-all.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.11"]
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.11']
     steps:
     - uses: actions/checkout@v3
 

--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -90,7 +90,7 @@ class SnapshotState(AstacusModel):
 
 class SnapshotRequest(NodeRequest):
     # list of globs, e.g. ["**/*.dat"] we want to back up from root
-    root_globs: List[str]
+    root_globs: Sequence[str]
 
 
 class SnapshotHash(AstacusModel):

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -15,7 +15,7 @@ from astacus.coordinator.config import CoordinatorNode
 from astacus.coordinator.manifest import download_backup_manifest
 from astacus.node.api import Features
 from collections import Counter
-from typing import Any, Counter as TCounter, Dict, Generic, List, Optional, Set, Type, TypeVar
+from typing import Any, Counter as TCounter, Dict, Generic, List, Optional, Sequence, Set, Type, TypeVar
 
 import dataclasses
 import datetime
@@ -81,7 +81,7 @@ class SnapshotStep(Step[List[ipc.SnapshotResult]]):
     see `SnapshotFile` for details.
     """
 
-    snapshot_root_globs: List[str]
+    snapshot_root_globs: Sequence[str]
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> List[ipc.SnapshotResult]:
         req = ipc.SnapshotRequest(root_globs=self.snapshot_root_globs)

--- a/astacus/coordinator/plugins/clickhouse/config.py
+++ b/astacus/coordinator/plugins/clickhouse/config.py
@@ -6,7 +6,10 @@ from .client import ClickHouseClient, HttpClickHouseClient
 from astacus.common.utils import AstacusModel, build_netloc
 from astacus.coordinator.plugins.zookeeper import KazooZooKeeperClient, ZooKeeperClient
 from astacus.coordinator.plugins.zookeeper_config import ZooKeeperConfiguration
+from pathlib import Path
 from typing import List, Optional
+
+import enum
 
 
 class ClickHouseNode(AstacusModel):
@@ -28,6 +31,17 @@ class ReplicatedDatabaseSettings(AstacusModel):
     cluster_password: Optional[str]
     cluster_secret: Optional[str]
     collection_name: Optional[str]
+
+
+class DiskType(enum.Enum):
+    local = "local"
+    object_storage = "object_storage"
+
+
+class DiskConfiguration(AstacusModel):
+    type: DiskType
+    path: Path
+    name: str
 
 
 def get_zookeeper_client(configuration: ZooKeeperConfiguration) -> ZooKeeperClient:

--- a/astacus/coordinator/plugins/clickhouse/disks.py
+++ b/astacus/coordinator/plugins/clickhouse/disks.py
@@ -1,0 +1,102 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+from .escaping import escape_for_file_name, unescape_from_file_name
+from pathlib import Path
+from typing import Sequence
+from uuid import UUID
+
+import dataclasses
+import re
+
+
+class PartFilePathError(ValueError):
+    def __init__(self, file_path: Path, error: str):
+        super().__init__(f"Unexpected part file path {file_path}: {error}")
+
+
+@dataclasses.dataclass(frozen=True)
+class ParsedPath:
+    disk_parts: tuple[str, ...]
+    freeze_name: bytes | None
+    table_uuid: UUID
+    detached: bool
+    part_name: bytes
+    file_parts: tuple[str, ...]
+
+    def to_path(self) -> Path:
+        parts = []
+        if self.freeze_name is not None:
+            parts.append("shadow")
+            parts.append(escape_for_file_name(self.freeze_name))
+        parts.append("store")
+        table_uuid_str = str(self.table_uuid)
+        parts.append(table_uuid_str[:3])
+        parts.append(table_uuid_str)
+        if self.detached:
+            parts.append("detached")
+        parts.append(escape_for_file_name(self.part_name))
+        return Path(*self.disk_parts, *parts, *self.file_parts)
+
+
+@dataclasses.dataclass(frozen=True)
+class DiskPaths:
+    _disk_paths_parts: Sequence[tuple[str, ...]] = dataclasses.field(default_factory=lambda: [()])
+
+    def get_frozen_parts_patterns(self, freeze_name: str) -> Sequence[str]:
+        """
+        Returns the glob patterns inside ClickHouse data dirs where frozen table parts are stored.
+        """
+        escaped_freeze_name = escape_for_file_name(freeze_name.encode())
+        frozen_parts_pattern = f"shadow/{escaped_freeze_name}/store/**/*"
+        return ["/".join((*disk_path_parts, frozen_parts_pattern)) for disk_path_parts in self._disk_paths_parts]
+
+    def parse_part_file_path(self, file_path: Path) -> ParsedPath:
+        """
+        Parse component of a file path relative to one of the ClickHouse disks.
+
+        The path can be in the normal store or in the frozen shadow store:
+            - [disk_path]/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/[file.ext]
+            - [disk_path]/shadow/[freeze_name]/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/[file.ext]
+        The part can be attached or detached:
+            - [disk_path]/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/[file.ext]
+            - [disk_path]/store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/[file.ext]
+        """
+        parts = file_path.parts
+        store_or_shadow_index = None
+        for disk_path_parts in self._disk_paths_parts:
+            if parts[: len(disk_path_parts)] == disk_path_parts:
+                store_or_shadow_index = len(disk_path_parts)
+                break
+        if store_or_shadow_index is None:
+            raise PartFilePathError(file_path, "should start with a disk path")
+        if parts[store_or_shadow_index] == "store":
+            freeze_name = None
+            uuid_index = store_or_shadow_index + 2
+        elif parts[store_or_shadow_index] == "shadow":
+            freeze_name = unescape_from_file_name(parts[store_or_shadow_index + 1])
+            uuid_index = store_or_shadow_index + 4
+        else:
+            raise PartFilePathError(file_path, "should start with 'store' or 'shadow' after the disk path")
+        if not re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", parts[uuid_index]):
+            raise PartFilePathError(file_path, "invalid table UUID")
+        if parts[uuid_index - 1] != parts[uuid_index][:3]:
+            raise PartFilePathError(
+                file_path,
+                " the parent folder to the UUID folder should have the 3 first characters of the UUID",
+            )
+        detached = parts[uuid_index + 1] == "detached"
+        part_name_index = uuid_index + (2 if detached else 1)
+        return ParsedPath(
+            disk_parts=parts[:store_or_shadow_index],
+            freeze_name=freeze_name,
+            table_uuid=UUID(parts[uuid_index]),
+            detached=detached,
+            part_name=unescape_from_file_name(parts[part_name_index]),
+            file_parts=parts[part_name_index + 1 :],
+        )
+
+    @classmethod
+    def from_disk_paths(cls, disk_paths: Sequence[Path]) -> "DiskPaths":
+        return DiskPaths(_disk_paths_parts=sorted([disk_path.parts for disk_path in disk_paths], key=len, reverse=True))

--- a/astacus/coordinator/plugins/clickhouse/parts.py
+++ b/astacus/coordinator/plugins/clickhouse/parts.py
@@ -8,15 +8,11 @@ Replicated family of table engines.
 This does not support shards, but this is the right place to add support for them.
 """
 from .disks import DiskPaths
-from .escaping import escape_for_file_name, unescape_from_file_name
 from .manifest import Table
-from .replication import DatabaseReplica
 from astacus.common.ipc import SnapshotFile, SnapshotResult
-from pathlib import Path
-from typing import AbstractSet, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+from typing import AbstractSet, Iterable, Mapping, Optional, Sequence, Set, Tuple
 
 import dataclasses
-import re
 import uuid
 
 
@@ -42,94 +38,6 @@ class Part:
     total_size: int
 
 
-def group_files_into_parts(
-    snapshot_files: List[List[SnapshotFile]],
-    tables_replicas: Mapping[uuid.UUID, Sequence[DatabaseReplica]],
-) -> Tuple[List[Part], List[List[SnapshotFile]]]:
-    """
-    Regroup all files that form a MergeTree table part together in a `Part`.
-
-    Only parts from the provided map of `tables_replicas` are regrouped.
-
-    Returns the list of `Part` and a separate list of list of `SnapshotFile` that
-    were not selected to make a `Part`.
-
-    The input and output list of lists will have the same length: the number
-    of server in the cluster (the first list is for the first server, etc.)
-    """
-    other_files: List[List[SnapshotFile]] = [[] for _ in snapshot_files]
-    keyed_parts: Dict[PartKey, Dict[Path, PartFile]] = {}
-    for server_index, server_files in enumerate(snapshot_files):
-        for snapshot_file in server_files:
-            if not add_file_to_parts(snapshot_file, server_index, tables_replicas, keyed_parts):
-                other_files[server_index].append(snapshot_file)
-    parts: list[Part] = []
-    for part_key, part_files in keyed_parts.items():
-        part_servers = get_part_servers(part_files.values())
-        part_snapshot_files = [part_file.snapshot_file for part_file in part_files.values()]
-        parts.append(
-            Part(
-                table_uuid=part_key.table_uuid,
-                part_name=part_key.part_name,
-                servers=part_servers,
-                snapshot_files=part_snapshot_files,
-                total_size=sum(snapshot_file.file_size for snapshot_file in part_snapshot_files),
-            )
-        )
-    return parts, other_files
-
-
-def add_file_to_parts(
-    snapshot_file: SnapshotFile,
-    server_index: int,
-    tables_replicas: Mapping[uuid.UUID, Sequence[DatabaseReplica]],
-    parts_files: Dict[PartKey, Dict[Path, PartFile]],
-) -> bool:
-    """
-    If the `snapshot_file` is a file from a part of one of the tables listed in
-    `replicated_tables`, add it to the corresponding dictionary in `parts_files`.
-
-    A file is from a part if its path starts with
-    "store/3_first_char_of_table_uuid/table_uuid/detached/part_name".
-
-    If a file already exists in a part, the `server_index` is added to the `server` set
-    of the `PartFile` for that file.
-
-    Raises a `ValueError` if a different file with the same name already exists in a
-    part: a `PartFile` must be the identical on all servers where it is present.
-
-    Returns `True` if and only if the file was added to a `Part`.
-    """
-    path_parts = snapshot_file.relative_path.parts
-    has_enough_depth = len(path_parts) >= 6
-    if not has_enough_depth:
-        return False
-    has_store_and_detached = path_parts[0] == "store" and path_parts[3] == "detached"
-    has_uuid_prefix = path_parts[1] == path_parts[2][:3]
-    has_valid_uuid = re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", path_parts[2])
-    if not (has_store_and_detached and has_uuid_prefix and has_valid_uuid):
-        return False
-    table_uuid = uuid.UUID(path_parts[2])
-    if table_uuid not in tables_replicas:
-        return False
-    shard_name = tables_replicas[table_uuid][server_index].shard_name
-    part_key = PartKey(table_uuid=table_uuid, shard_name=shard_name, part_name=unescape_from_file_name(path_parts[4]))
-    part_files = parts_files.setdefault(part_key, {})
-    part_file = part_files.get(snapshot_file.relative_path)
-    if part_file is None:
-        part_files[snapshot_file.relative_path] = PartFile(snapshot_file=snapshot_file, servers={server_index})
-    elif part_file.snapshot_file.equals_excluding_mtime(snapshot_file):
-        part_files[snapshot_file.relative_path] = dataclasses.replace(part_file, servers=part_file.servers | {server_index})
-    else:
-        raise ValueError(
-            f"Inconsistent part file {snapshot_file.relative_path} of part {part_key} "
-            f"between servers {part_file.servers} and server {server_index}:\n"
-            f"    {part_file.snapshot_file}\n"
-            f"    {snapshot_file}"
-        )
-    return True
-
-
 def get_part_servers(part_files: Iterable[PartFile]) -> AbstractSet[int]:
     """
     Return the list of server indices where the part made of all these files is present.
@@ -148,29 +56,6 @@ def get_part_servers(part_files: Iterable[PartFile]) -> AbstractSet[int]:
             )
     assert part_servers is not None
     return part_servers
-
-
-def distribute_parts_to_servers(parts: Sequence[Part], server_files: List[List[SnapshotFile]]):
-    """
-    Distributes each part to only one of the multiple servers where the part was
-    during the backup.
-
-    Parts are distributed to each server such as the total download size for each
-    server is roughly equal (using a greedy algorithm).
-    """
-    total_file_sizes = [0 for _ in server_files]
-    for part in sorted(parts, key=lambda p: p.total_size, reverse=True):
-        server_index = min(part.servers, key=total_file_sizes.__getitem__)
-        server_files[server_index].extend(part.snapshot_files)
-        total_file_sizes[server_index] += part.total_size
-
-
-def get_frozen_parts_pattern(freeze_name: str) -> str:
-    """
-    Returns the glob pattern inside ClickHouse data dir where frozen table parts are stored.
-    """
-    escaped_freeze_name = escape_for_file_name(freeze_name.encode())
-    return f"shadow/{escaped_freeze_name}/store/**/*"
 
 
 def list_parts_to_attach(

--- a/astacus/coordinator/plugins/clickhouse/plugin.py
+++ b/astacus/coordinator/plugins/clickhouse/plugin.py
@@ -69,7 +69,6 @@ class ClickHousePlugin(CoordinatorPlugin):
             RemoveFrozenTablesStep(
                 clients=clickhouse_clients,
                 freeze_name=self.freeze_name,
-                use_system_unfreeze=self.use_system_unfreeze,
                 unfreeze_timeout=self.unfreeze_timeout,
             ),
             # Collect the users, database and tables

--- a/astacus/coordinator/plugins/clickhouse/replication.py
+++ b/astacus/coordinator/plugins/clickhouse/replication.py
@@ -4,7 +4,7 @@ See LICENSE for details
 """
 from .client import ClickHouseClient, escape_sql_identifier, unescape_sql_string
 from .macros import MacroExpansionError, Macros
-from .manifest import ReplicatedDatabase, Table
+from .manifest import ReplicatedDatabase
 from .sql import chain_of, named_group, one_of, TokenType
 from astacus.coordinator.plugins.base import StepFailedError
 from astacus.coordinator.plugins.zookeeper import ZooKeeperConnection
@@ -14,7 +14,6 @@ from typing import Mapping, Optional, Sequence
 import asyncio
 import dataclasses
 import re
-import uuid
 
 
 @dataclasses.dataclass(frozen=True)
@@ -132,18 +131,3 @@ def get_databases_replicas(
                 raise StepFailedError(f"Error in macro of server {server_index}: {e}") from e
         databases_replicas[database.name] = replicas
     return databases_replicas
-
-
-def get_tables_replicas(
-    replicated_tables: Sequence[Table], databases_replicas: Mapping[bytes, Sequence[DatabaseReplica]]
-) -> Mapping[uuid.UUID, Sequence[DatabaseReplica]]:
-    """
-    Get the list of replicas for each Table.
-
-    This maps the database of each table to the replicas of each database.
-
-    This is only correct for clusters where the database and the tables inside
-    that database use the same sharding strategy, which should be the case
-    for Replicated databases.
-    """
-    return {table.uuid: databases_replicas[table.database] for table in replicated_tables}

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.11
 plugins = pydantic.mypy
 
 show_error_codes = True

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,6 @@ def _run():
             "Intended Audience :: Information Technology",
             "Intended Audience :: System Administrators",
             "License :: OSI Approved :: Apache Software License",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Topic :: Database :: Database Engines/Servers",
             "Topic :: Software Development :: Libraries",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,8 @@ See LICENSE for details
 from astacus.common.utils import build_netloc
 from astacus.coordinator.plugins.zookeeper import KazooZooKeeperClient
 from pathlib import Path
-from typing import AsyncIterator, Dict, Iterator, List, Optional, Union
+from types import MappingProxyType
+from typing import AsyncIterator, Iterator, List, Mapping, Optional, Union
 
 import asyncio
 import contextlib
@@ -65,19 +66,19 @@ async def run_process_and_wait_for_pattern(
     cwd: Path,
     pattern: str,
     fail_pattern: Optional[str] = None,
+    env: Mapping[str, str] = MappingProxyType({}),
     timeout: float = 10.0,
 ) -> AsyncIterator[asyncio.subprocess.Process]:
     # This stringification is a workaround for a bug in pydev (pydev_monkey.py:111)
     str_args = [str(arg) for arg in args]
-    env: Dict[str, str] = {}
     pattern_found = asyncio.Event()
     loop = asyncio.get_running_loop()
-    with subprocess.Popen(str_args, cwd=cwd, env=env, stderr=subprocess.PIPE) as process:
+    with subprocess.Popen(str_args, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as process:
 
         def read_logs() -> None:
-            assert process.stderr is not None
+            assert process.stdout is not None
             while process.poll() is None:
-                for line in process.stderr:
+                for line in process.stdout:
                     line = line.rstrip(b"\n")
                     decoded_line = line.rstrip(b"\n").decode(encoding="utf-8", errors="replace")
                     logger.debug("%d: %s", process.pid, decoded_line)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,7 @@ import contextlib
 import dataclasses
 import logging
 import pytest
+import socket
 import subprocess
 import tempfile
 import threading
@@ -114,13 +115,24 @@ class ServiceCluster:
 
 
 class Ports:
-    def __init__(self, start: int = 50000):
+    def __init__(self, start: int = 15000):
         self.start = start
 
     def allocate(self) -> int:
+        while port_is_listening("127.0.0.1", self.start):
+            self.start += 1
         allocated = self.start
         self.start += 1
         return allocated
+
+
+def port_is_listening(hostname: str, port: int, timeout: float = 0.5) -> bool:
+    try:
+        connection = socket.create_connection((hostname, port), timeout)
+        connection.close()
+        return True
+    except socket.error:
+        return False
 
 
 @pytest.fixture(scope="session", name="ports")

--- a/tests/integration/coordinator/plugins/clickhouse/conftest.py
+++ b/tests/integration/coordinator/plugins/clickhouse/conftest.py
@@ -17,7 +17,13 @@ from astacus.common.utils import build_netloc
 from astacus.config import GlobalConfig, UvicornConfig
 from astacus.coordinator.config import CoordinatorConfig, CoordinatorNode
 from astacus.coordinator.plugins.clickhouse.client import HttpClickHouseClient
-from astacus.coordinator.plugins.clickhouse.config import ClickHouseConfiguration, ClickHouseNode, ReplicatedDatabaseSettings
+from astacus.coordinator.plugins.clickhouse.config import (
+    ClickHouseConfiguration,
+    ClickHouseNode,
+    DiskConfiguration,
+    DiskType,
+    ReplicatedDatabaseSettings,
+)
 from astacus.coordinator.plugins.clickhouse.plugin import ClickHousePlugin
 from astacus.coordinator.plugins.zookeeper_config import ZooKeeperConfiguration, ZooKeeperNode
 from astacus.node.config import NodeConfig
@@ -468,6 +474,10 @@ def create_astacus_configs(
                         cluster_username=clickhouse_cluster.services[0].username,
                         cluster_password=clickhouse_cluster.services[0].password,
                     ),
+                    disks=[
+                        DiskConfiguration(type=DiskType.local, path=Path(""), name="default"),
+                        DiskConfiguration(type=DiskType.object_storage, path=Path("disks/remote"), name="remote"),
+                    ],
                     sync_databases_timeout=10.0,
                     sync_tables_timeout=30.0,
                 ).jsondict(),

--- a/tests/integration/coordinator/plugins/clickhouse/conftest.py
+++ b/tests/integration/coordinator/plugins/clickhouse/conftest.py
@@ -280,10 +280,8 @@ async def create_astacus_cluster(
     zookeeper: Service,
     clickhouse_cluster: ClickHouseServiceCluster,
     ports: Ports,
-    *,
-    use_system_unfreeze: bool,
 ) -> AsyncIterator[ServiceCluster]:
-    configs = create_astacus_configs(zookeeper, clickhouse_cluster, ports, Path(storage_path), use_system_unfreeze)
+    configs = create_astacus_configs(zookeeper, clickhouse_cluster, ports, Path(storage_path))
     async with contextlib.AsyncExitStack() as stack:
         astacus_services_coro: List[Awaitable] = [stack.enter_async_context(_astacus(config=config)) for config in configs]
         astacus_services = list(await asyncio.gather(*astacus_services_coro))
@@ -438,7 +436,6 @@ def create_astacus_configs(
     clickhouse_cluster: ClickHouseServiceCluster,
     ports: Ports,
     storage_path: Path,
-    use_system_unfreeze: bool,
 ) -> List[GlobalConfig]:
     storage_tmp_path = storage_path / "tmp"
     storage_tmp_path.mkdir(exist_ok=True)
@@ -473,7 +470,6 @@ def create_astacus_configs(
                     ),
                     sync_databases_timeout=10.0,
                     sync_tables_timeout=30.0,
-                    use_system_unfreeze=use_system_unfreeze,
                 ).jsondict(),
             ),
             node=NodeConfig(

--- a/tests/integration/coordinator/plugins/clickhouse/test_plugin.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_plugin.py
@@ -165,7 +165,9 @@ async def test_restores_access_entities(restored_cluster: List[ClickHouseClient]
             b"SELECT base64Encode(name) FROM system.users WHERE storage = 'replicated' ORDER BY name"
         ) == [[_b64_str(b"alice")], [_b64_str(b"z_\x80_enjoyer")]]
         assert await client.execute(b"SELECT name FROM system.roles WHERE storage = 'replicated' ORDER BY name") == [["bob"]]
-        assert await client.execute(b"SELECT user_name,role_name FROM system.grants ORDER BY user_name,role_name") == [
+        assert await client.execute(
+            b"SELECT DISTINCT user_name,role_name FROM system.grants ORDER BY user_name,role_name"
+        ) == [
             ["alice", None],
             ["default", None],
             [None, "bob"],

--- a/tests/integration/coordinator/plugins/clickhouse/test_replication.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_replication.py
@@ -8,6 +8,7 @@ from tests.integration.coordinator.plugins.clickhouse.conftest import (
     ClickHouseCommand,
     create_clickhouse_cluster,
     get_clickhouse_client,
+    MinioBucket,
 )
 
 import pytest
@@ -19,9 +20,11 @@ pytestmark = [
 
 
 @pytest.mark.asyncio
-async def test_get_shard_and_replica(ports: Ports, clickhouse_command: ClickHouseCommand) -> None:
+async def test_get_shard_and_replica(ports: Ports, clickhouse_command: ClickHouseCommand, minio_bucket: MinioBucket) -> None:
     async with create_zookeeper(ports) as zookeeper:
-        async with create_clickhouse_cluster(zookeeper, ports, ["s1"], clickhouse_command) as clickhouse_cluster:
+        async with create_clickhouse_cluster(
+            zookeeper, minio_bucket, ports, ["s1"], clickhouse_command
+        ) as clickhouse_cluster:
             clickhouse = clickhouse_cluster.services[0]
             client = get_clickhouse_client(clickhouse)
             await client.execute(

--- a/tests/integration/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_steps.py
@@ -2,7 +2,7 @@
 Copyright (c) 2021 Aiven Ltd
 See LICENSE for details
 """
-from .conftest import ClickHouseCommand, create_clickhouse_cluster, get_clickhouse_client
+from .conftest import ClickHouseCommand, create_clickhouse_cluster, get_clickhouse_client, MinioBucket
 from astacus.coordinator.cluster import Cluster
 from astacus.coordinator.plugins.base import StepsContext
 from astacus.coordinator.plugins.clickhouse.manifest import ReplicatedDatabase, Table
@@ -20,10 +20,12 @@ pytestmark = [
 
 
 @pytest.mark.asyncio
-async def test_retrieve_tables(ports: Ports, clickhouse_command: ClickHouseCommand) -> None:
+async def test_retrieve_tables(ports: Ports, clickhouse_command: ClickHouseCommand, minio_bucket: MinioBucket) -> None:
     async with create_zookeeper(ports) as zookeeper:
         # We need a "real" cluster to be able to use Replicated databases
-        async with create_clickhouse_cluster(zookeeper, ports, ["s1"], clickhouse_command) as clickhouse_cluster:
+        async with create_clickhouse_cluster(
+            zookeeper, minio_bucket, ports, ["s1"], clickhouse_command
+        ) as clickhouse_cluster:
             clickhouse = clickhouse_cluster.services[0]
             client = get_clickhouse_client(clickhouse)
             await client.execute(

--- a/tests/unit/coordinator/plugins/clickhouse/test_disks.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_disks.py
@@ -1,0 +1,118 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+from astacus.coordinator.plugins.clickhouse.disks import DiskPaths, ParsedPath
+from pathlib import Path
+from uuid import UUID
+
+
+def test_get_frozen_parts_pattern_escapes_backup_name() -> None:
+    disk_paths = DiskPaths()
+    assert disk_paths.get_frozen_parts_patterns("something+stra/../nge") == [
+        "shadow/something%2Bstra%2F%2E%2E%2Fnge/store/**/*"
+    ]
+
+
+def test_parse_part_file_path() -> None:
+    disk_paths = DiskPaths()
+    parsed_path = disk_paths.parse_part_file_path(
+        Path("store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")
+    )
+    assert parsed_path == ParsedPath(
+        disk_parts=(),
+        freeze_name=None,
+        table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
+        detached=False,
+        part_name=b"all_1_1_0",
+        file_parts=("checksum.txt",),
+    )
+
+
+def test_parse_detached_part_file_path() -> None:
+    disk_paths = DiskPaths()
+    parsed_path = disk_paths.parse_part_file_path(
+        Path("store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt")
+    )
+    assert parsed_path == ParsedPath(
+        disk_parts=(),
+        freeze_name=None,
+        table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
+        detached=True,
+        part_name=b"all_1_1_0",
+        file_parts=("checksum.txt",),
+    )
+
+
+def test_parse_shadow_part_file_path() -> None:
+    disk_paths = DiskPaths()
+    parsed_path = disk_paths.parse_part_file_path(
+        Path("shadow/astacus/store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt")
+    )
+    assert parsed_path == ParsedPath(
+        disk_parts=(),
+        freeze_name=b"astacus",
+        table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
+        detached=True,
+        part_name=b"all_1_1_0",
+        file_parts=("checksum.txt",),
+    )
+
+
+def test_parse_part_file_path_on_other_disk() -> None:
+    disk_paths = DiskPaths.from_disk_paths([Path(), Path("disks/secondary")])
+    parsed_path = disk_paths.parse_part_file_path(
+        Path("disks/secondary/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")
+    )
+    assert parsed_path == ParsedPath(
+        disk_parts=("disks", "secondary"),
+        freeze_name=None,
+        table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
+        detached=False,
+        part_name=b"all_1_1_0",
+        file_parts=("checksum.txt",),
+    )
+
+
+def test_parsed_path_to_path() -> None:
+    assert ParsedPath(
+        disk_parts=(),
+        freeze_name=None,
+        table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
+        detached=False,
+        part_name=b"all_1_1_0",
+        file_parts=("checksum.txt",),
+    ).to_path() == Path("store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")
+
+
+def test_detached_parsed_path_to_path() -> None:
+    assert ParsedPath(
+        disk_parts=(),
+        freeze_name=None,
+        table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
+        detached=True,
+        part_name=b"all_1_1_0",
+        file_parts=("checksum.txt",),
+    ).to_path() == Path("store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt")
+
+
+def test_shadow_parsed_path_to_path() -> None:
+    assert ParsedPath(
+        disk_parts=(),
+        freeze_name=b"this/is\x80weird",
+        table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
+        detached=False,
+        part_name=b"all_1_1_0",
+        file_parts=("checksum.txt",),
+    ).to_path() == Path("shadow/this%2Fis%80weird/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")
+
+
+def test_other_disk_parsed_path_to_path() -> None:
+    assert ParsedPath(
+        disk_parts=("disks", "secondary"),
+        freeze_name=None,
+        table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
+        detached=False,
+        part_name=b"all_1_1_0",
+        file_parts=("checksum.txt",),
+    ).to_path() == Path("disks/secondary/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")

--- a/tests/unit/coordinator/plugins/clickhouse/test_manifest.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_manifest.py
@@ -2,7 +2,13 @@
 Copyright (c) 2021 Aiven Ltd
 See LICENSE for details
 """
-from astacus.coordinator.plugins.clickhouse.manifest import AccessEntity, ClickHouseManifest, ReplicatedDatabase, Table
+from astacus.coordinator.plugins.clickhouse.manifest import (
+    AccessEntity,
+    ClickHouseBackupVersion,
+    ClickHouseManifest,
+    ReplicatedDatabase,
+    Table,
+)
 from base64 import b64encode
 
 import pytest
@@ -118,12 +124,30 @@ def test_table_from_plugin_data() -> None:
 def test_clickhouse_manifest_from_plugin_data() -> None:
     manifest = ClickHouseManifest.from_plugin_data(
         {
+            "version": "v2",
             "access_entities": [SERIALIZED_ACCESS_ENTITY],
             "replicated_databases": [SERIALIZED_DATABASE],
             "tables": [SERIALIZED_TABLE],
         }
     )
     assert manifest == ClickHouseManifest(
+        version=ClickHouseBackupVersion.V2,
+        access_entities=[SAMPLE_ACCESS_ENTITY],
+        replicated_databases=[SAMPLE_DATABASE],
+        tables=[SAMPLE_TABLE],
+    )
+
+
+def test_clickhouse_manifest_from_v1_plugin_data() -> None:
+    manifest = ClickHouseManifest.from_plugin_data(
+        {
+            "access_entities": [SERIALIZED_ACCESS_ENTITY],
+            "replicated_databases": [SERIALIZED_DATABASE],
+            "tables": [SERIALIZED_TABLE],
+        }
+    )
+    assert manifest == ClickHouseManifest(
+        version=ClickHouseBackupVersion.V1,
         access_entities=[SAMPLE_ACCESS_ENTITY],
         replicated_databases=[SAMPLE_DATABASE],
         tables=[SAMPLE_TABLE],
@@ -132,11 +156,13 @@ def test_clickhouse_manifest_from_plugin_data() -> None:
 
 def test_clickhouse_manifest_to_plugin_data() -> None:
     serialized_manifest = ClickHouseManifest(
+        version=ClickHouseBackupVersion.V2,
         access_entities=[SAMPLE_ACCESS_ENTITY],
         replicated_databases=[SAMPLE_DATABASE],
         tables=[SAMPLE_TABLE],
     ).to_plugin_data()
     assert serialized_manifest == {
+        "version": "v2",
         "access_entities": [SERIALIZED_ACCESS_ENTITY],
         "replicated_databases": [SERIALIZED_DATABASE],
         "tables": [SERIALIZED_TABLE],

--- a/tests/unit/coordinator/plugins/clickhouse/test_parts.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_parts.py
@@ -21,6 +21,7 @@ from typing import List
 from uuid import UUID
 
 import copy
+import dataclasses
 import hashlib
 import pytest
 
@@ -234,7 +235,7 @@ def test_get_part_servers_succeeds_on_valid_parts() -> None:
 
 def test_get_part_servers_fails_on_inconsistent_servers_set() -> None:
     part_files = [PartFile(snapshot_file=file, servers={0, 1}) for file in TABLE_1_PART_1]
-    part_files[1].servers = {0, 1, 2}
+    part_files[1] = dataclasses.replace(part_files[1], servers={0, 1, 2})
     with pytest.raises(ValueError):
         get_part_servers(part_files)
 

--- a/tests/unit/coordinator/plugins/clickhouse/test_parts.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_parts.py
@@ -5,23 +5,12 @@ See LICENSE for details
 from astacus.common.ipc import SnapshotFile, SnapshotResult, SnapshotState
 from astacus.coordinator.plugins.clickhouse.disks import DiskPaths
 from astacus.coordinator.plugins.clickhouse.manifest import Table
-from astacus.coordinator.plugins.clickhouse.parts import (
-    add_file_to_parts,
-    distribute_parts_to_servers,
-    get_frozen_parts_pattern,
-    get_part_servers,
-    group_files_into_parts,
-    list_parts_to_attach,
-    Part,
-    PartFile,
-    PartKey,
-)
+from astacus.coordinator.plugins.clickhouse.parts import get_part_servers, list_parts_to_attach, Part, PartFile
 from astacus.coordinator.plugins.clickhouse.replication import DatabaseReplica
 from pathlib import Path
 from typing import List
 from uuid import UUID
 
-import copy
 import dataclasses
 import hashlib
 import pytest
@@ -68,167 +57,6 @@ SHARDED_DATABASE_REPLICAS = [
 ]
 
 
-def test_group_files_into_parts_collects_parts_from_selected_tables() -> None:
-    first_server_files = copy.deepcopy([*TABLE_1_PART_1, *TABLE_1_PART_2, *TABLE_1_PART_3])
-    second_server_files = copy.deepcopy([*TABLE_1_PART_1, *TABLE_1_PART_2, *TABLE_1_PART_3])
-    tables_replicas = {T1_UUID: DATABASES_REPLICAS, T2_UUID: DATABASES_REPLICAS}
-    parts, other_files = group_files_into_parts([first_server_files, second_server_files], tables_replicas)
-    assert len(parts) == 3
-    for part, original_files in zip(parts, [TABLE_1_PART_1, TABLE_1_PART_2, TABLE_1_PART_3]):
-        assert part.snapshot_files == original_files
-        assert part.total_size == 1120
-        assert part.servers == {0, 1}
-    assert other_files == [[], []]
-
-
-def test_group_files_into_parts_does_not_merge_unreplicated_parts_within_shard() -> None:
-    first_server_files = copy.deepcopy(TABLE_1_PART_1)
-    second_server_files = copy.deepcopy(TABLE_1_PART_2)
-    tables_replicas = {T1_UUID: DATABASES_REPLICAS, T2_UUID: DATABASES_REPLICAS}
-    parts, other_files = group_files_into_parts([first_server_files, second_server_files], tables_replicas)
-    server_1_parts = [part for part in parts if part.servers == {0}]
-    server_2_parts = [part for part in parts if part.servers == {1}]
-    assert len(server_1_parts) == 1
-    assert server_1_parts[0].snapshot_files == TABLE_1_PART_1
-    assert len(server_2_parts) == 1
-    assert server_2_parts[0].snapshot_files == TABLE_1_PART_2
-    assert other_files == [[], []]
-
-
-def test_group_files_into_parts_does_not_merge_parts_across_shards() -> None:
-    first_server_files = copy.deepcopy([*TABLE_1_PART_1, *TABLE_1_PART_2, *TABLE_1_PART_3])
-    second_server_files = copy.deepcopy([*TABLE_1_PART_1, *TABLE_1_PART_2, *TABLE_1_PART_3])
-    tables_replicas = {T1_UUID: SHARDED_DATABASE_REPLICAS, T2_UUID: SHARDED_DATABASE_REPLICAS}
-    parts, other_files = group_files_into_parts([first_server_files, second_server_files], tables_replicas)
-    # Because each server is in a different shard, despite having the same data
-    # we have twice as many part as the test where all servers were in the
-    # same shard.
-    server_1_parts = [part for part in parts if part.servers == {0}]
-    server_2_parts = [part for part in parts if part.servers == {1}]
-    assert len(server_1_parts) == 3
-    assert len(server_2_parts) == 3
-    for part, original_files in zip(server_1_parts, [TABLE_1_PART_1, TABLE_1_PART_2, TABLE_1_PART_3]):
-        assert part.snapshot_files == original_files
-    for part, original_files in zip(server_2_parts, [TABLE_1_PART_1, TABLE_1_PART_2, TABLE_1_PART_3]):
-        assert part.snapshot_files == original_files
-    assert other_files[0] == []
-    assert other_files[1] == []
-
-
-def test_group_files_into_parts_ignores_parts_from_unselected_tables() -> None:
-    first_server_files = copy.deepcopy([*TABLE_3_PART_1A])
-    second_server_files = copy.deepcopy([*TABLE_3_PART_1B])
-    tables_replicas = {T1_UUID: DATABASES_REPLICAS, T2_UUID: DATABASES_REPLICAS}
-    parts, other_files = group_files_into_parts([first_server_files, second_server_files], tables_replicas)
-    assert parts == []
-    assert other_files[0] == TABLE_3_PART_1A
-    assert other_files[1] == TABLE_3_PART_1B
-
-
-def test_group_files_into_parts_ignores_unknown_files() -> None:
-    first_server_files = [SnapshotFile(relative_path=Path("something/random_a"), file_size=100, mtime_ns=0)]
-    second_server_files = [SnapshotFile(relative_path=Path("something/random_B"), file_size=100, mtime_ns=0)]
-    tables_replicas = {T1_UUID: DATABASES_REPLICAS, T2_UUID: DATABASES_REPLICAS}
-    parts, other_files = group_files_into_parts([first_server_files, second_server_files], tables_replicas)
-    assert parts == []
-    assert other_files[0] == first_server_files
-    assert other_files[1] == second_server_files
-
-
-@pytest.mark.parametrize(
-    "file_path",
-    [
-        Path("something/random_a"),
-        Path("notstore/000/00000000-0000-0000-0000-000000000001/detached/all_0_0_0/data.bin"),
-        Path("store/123/00000000-0000-0000-0000-000000000001/detached/all_0_0_0/data.bin"),
-        Path("store/000/00000000-0000-0bad0-0000-000000000002/detached/all_0_0_0/data.bin"),
-        Path("store/000/00000000-0000-0000-0000-000000000002/detached/all_0_0_0/data.bin"),
-        Path("store/000/00000000-0000-0000-0000-000000000001/notdetached/all_0_0_0/data.bin"),
-        Path("store/000/00000000-0000-0000-0000-000000000001/detached/notapart.txt"),
-    ],
-    ids=["random", "not-store", "wrong-uuid-prefix", "invalid-uuid", "wrong-uuid", "not-detached", "not-folder"],
-)
-def test_add_file_to_parts_ignores_unknown_files(file_path: Path) -> None:
-    snapshot_file = SnapshotFile(relative_path=file_path, file_size=100, mtime_ns=0)
-    parts_files = {}
-    tables_replicas = {T1_UUID: [DatabaseReplica(shard_name="shard_1", replica_name="node_1")]}
-    added = add_file_to_parts(
-        snapshot_file=snapshot_file, server_index=0, tables_replicas=tables_replicas, parts_files=parts_files
-    )
-    assert added is False
-    assert len(parts_files) == 0
-
-
-def test_add_file_to_parts_adds_file() -> None:
-    file_a = SnapshotFile(
-        relative_path=Path("store/000/00000000-0000-0000-0000-000000000001/detached/all_0_0_0/data.bin"),
-        file_size=100,
-        mtime_ns=0,
-        hexdigest="0001",
-    )
-    parts_files = {}
-    tables_replicas = {T1_UUID: [DatabaseReplica(shard_name="shard_1", replica_name="node_1")]}
-    added = add_file_to_parts(snapshot_file=file_a, server_index=0, tables_replicas=tables_replicas, parts_files=parts_files)
-    assert added is True
-    part_files = parts_files[PartKey(table_uuid=T1_UUID, shard_name="shard_1", part_name=b"all_0_0_0")]
-    assert part_files == {file_a.relative_path: PartFile(snapshot_file=file_a, servers={0})}
-
-
-def test_add_file_to_parts_collects_all_servers() -> None:
-    file_a = SnapshotFile(
-        relative_path=Path("store/000/00000000-0000-0000-0000-000000000001/detached/all_0_0_0/data.bin"),
-        file_size=100,
-        mtime_ns=0,
-        hexdigest="0001",
-    )
-    parts = {}
-    tables_replicas = {
-        T1_UUID: [
-            DatabaseReplica(shard_name="shard_1", replica_name="node_1"),
-            DatabaseReplica(shard_name="shard_1", replica_name="node_2"),
-            DatabaseReplica(shard_name="shard_1", replica_name="node_3"),
-        ]
-    }
-    for server_index in range(3):
-        add_file_to_parts(
-            snapshot_file=file_a, server_index=server_index, tables_replicas=tables_replicas, parts_files=parts
-        )
-    part_files = parts[PartKey(table_uuid=T1_UUID, shard_name="shard_1", part_name=b"all_0_0_0")]
-    part_file = part_files[file_a.relative_path]
-    assert part_file.servers == {0, 1, 2}
-
-
-def test_add_file_to_parts_fails_on_inconsistent_file() -> None:
-    # Same filename from two different servers but different hash
-    file_a = SnapshotFile(
-        relative_path=Path("store/000/00000000-0000-0000-0000-000000000001/detached/all_0_0_0/data.bin"),
-        file_size=100,
-        mtime_ns=0,
-        hexdigest="0001",
-    )
-    file_b = file_a.copy(update={"hexdigest": "0002"})
-    parts = {}
-    tables_replicas = {T1_UUID: DATABASES_REPLICAS}
-    add_file_to_parts(snapshot_file=file_a, server_index=0, tables_replicas=tables_replicas, parts_files=parts)
-    with pytest.raises(ValueError):
-        add_file_to_parts(snapshot_file=file_b, server_index=1, tables_replicas=tables_replicas, parts_files=parts)
-
-
-def test_add_file_to_parts_ignores_inconsistent_modification_time() -> None:
-    file_a = SnapshotFile(
-        relative_path=Path("store/000/00000000-0000-0000-0000-000000000001/detached/all_0_0_0/data.bin"),
-        file_size=100,
-        mtime_ns=123456,
-        hexdigest="0001",
-    )
-    file_b = file_a.copy(update={"mtime_ns": 789789})
-    parts = {}
-    tables_replicas = {T1_UUID: DATABASES_REPLICAS}
-    add_file_to_parts(snapshot_file=file_a, server_index=0, tables_replicas=tables_replicas, parts_files=parts)
-    added = add_file_to_parts(snapshot_file=file_b, server_index=1, tables_replicas=tables_replicas, parts_files=parts)
-    assert added is True
-
-
 def test_get_part_servers_succeeds_on_valid_parts() -> None:
     get_part_servers([PartFile(snapshot_file=file, servers={0, 1}) for file in TABLE_1_PART_1])
     get_part_servers([PartFile(snapshot_file=file, servers={0}) for file in TABLE_3_PART_1B])
@@ -239,32 +67,6 @@ def test_get_part_servers_fails_on_inconsistent_servers_set() -> None:
     part_files[1] = dataclasses.replace(part_files[1], servers={0, 1, 2})
     with pytest.raises(ValueError):
         get_part_servers(part_files)
-
-
-def test_distribute_parts_to_servers_balances_parts() -> None:
-    table_parts = [TABLE_1_PART_1, TABLE_1_PART_2, TABLE_1_PART_3]
-    parts = [create_part_from_part_files(part_files) for part_files in table_parts]
-    server_files: List[List[SnapshotFile]] = [[], []]
-    distribute_parts_to_servers(parts, server_files)
-    for part, server_index in zip(table_parts, (0, 1, 0)):
-        for part_file in part:
-            assert part_file in server_files[server_index]
-
-
-def test_distribute_parts_to_servers_balances_part_sizes() -> None:
-    large_part_3 = copy.deepcopy(TABLE_1_PART_3)
-    large_part_3[0].file_size *= 2
-    table_parts = [TABLE_1_PART_1, TABLE_1_PART_2, large_part_3]
-    parts = [create_part_from_part_files(part_files) for part_files in table_parts]
-    server_files: List[List[SnapshotFile]] = [[], []]
-    distribute_parts_to_servers(parts, server_files)
-    for part, server_index in zip(table_parts, (1, 1, 0)):
-        for part_file in part:
-            assert part_file in server_files[server_index]
-
-
-def test_get_frozen_parts_pattern_escapes_backup_name() -> None:
-    assert get_frozen_parts_pattern("something+stra/../nge") == "shadow/something%2Bstra%2F%2E%2E%2Fnge/store/**/*"
 
 
 def test_list_parts_to_attach() -> None:

--- a/tests/unit/coordinator/plugins/clickhouse/test_replication.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_replication.py
@@ -3,8 +3,8 @@ Copyright (c) 2021 Aiven Ltd
 See LICENSE for details
 """
 from astacus.coordinator.plugins.clickhouse.macros import Macros
-from astacus.coordinator.plugins.clickhouse.manifest import ReplicatedDatabase, Table
-from astacus.coordinator.plugins.clickhouse.replication import DatabaseReplica, get_databases_replicas, get_tables_replicas
+from astacus.coordinator.plugins.clickhouse.manifest import ReplicatedDatabase
+from astacus.coordinator.plugins.clickhouse.replication import DatabaseReplica, get_databases_replicas
 from uuid import UUID
 
 
@@ -24,46 +24,6 @@ def test_get_databases_replicas() -> None:
             DatabaseReplica(shard_name="all", replica_name="r2"),
         ],
         b"sharded_db": [
-            DatabaseReplica(shard_name="s1", replica_name="r1"),
-            DatabaseReplica(shard_name="s2", replica_name="r2"),
-        ],
-    }
-
-
-def test_get_tables_replicas() -> None:
-    replicated_tables = [
-        Table(
-            database=b"default_db",
-            name=b"table_one",
-            engine="ReplicatedMergeTree",
-            uuid=UUID(int=3),
-            create_query=b"CREATE ...",
-        ),
-        Table(
-            database=b"sharded_db",
-            name=b"table_two",
-            engine="ReplicatedMergeTree",
-            uuid=UUID(int=4),
-            create_query=b"CREATE ...",
-        ),
-    ]
-    databases_replicas = {
-        b"default_db": [
-            DatabaseReplica(shard_name="all", replica_name="r1"),
-            DatabaseReplica(shard_name="all", replica_name="r2"),
-        ],
-        b"sharded_db": [
-            DatabaseReplica(shard_name="s1", replica_name="r1"),
-            DatabaseReplica(shard_name="s2", replica_name="r2"),
-        ],
-    }
-    tables_replicas = get_tables_replicas(replicated_tables, databases_replicas)
-    assert tables_replicas == {
-        UUID(int=3): [
-            DatabaseReplica(shard_name="all", replica_name="r1"),
-            DatabaseReplica(shard_name="all", replica_name="r2"),
-        ],
-        UUID(int=4): [
             DatabaseReplica(shard_name="s1", replica_name="r1"),
             DatabaseReplica(shard_name="s2", replica_name="r2"),
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310
+envlist = py311
 
 
 [testenv]
@@ -9,7 +9,3 @@ deps =
 
 commands =
   py.test
-
-[testenv:py38]
-commands =
-  py.test --cov-report html --cov=.tox/py38/lib/python3.8/site-packages/astacus


### PR DESCRIPTION
The first thing is to support the disk prefix at the beginning of the file
path (anything before the store or shadow folder).

Some disks have metadata files instead of actual files in their store
folder, like object storage disks.

Even when the content is the same between replicas, the file
in object storage can be different, which makes the metadata files
different.

Because of that, we can't distribute parts among replicas and
we can't use a replicated ATTACH to exchange the data.

Even if we did, that wouldn't work great with all replication modes that
can be used in ClickHouse.

To fix that, stop doing parts distribution entirely and download all
parts from all nodes. To avoid the replication induced by ATTACH, replace
that with a SYSTEM RECOVER REPLICA: we remove the information in
ZooKeeper about the table replica, then force the disk content to be the
source of truth to recreate the ZooKeeper state.

When restoring a backup, we need to know if it's an old one that needs
to be restored with ATTACH/SYNC, or a new one that needs RESTART/RECOVER.
To detect that, introduce a version in the ClickHouse part of the manifest.

[DDB-498]

[DDB-498]: https://aiven.atlassian.net/browse/DDB-498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ