### PR TITLE
clickhouse: extract the path of remote files 

### DIFF
--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -6,7 +6,7 @@ See LICENSE for details
 # pydantic validators are class methods in disguise
 # pylint: disable=no-self-argument
 
-from .magic import StrEnum
+from .magic import DEFAULT_EMBEDDED_FILE_SIZE, StrEnum
 from .progress import Progress
 from .utils import AstacusModel, now, SizeLimitedFile
 from datetime import datetime

--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -95,6 +95,8 @@ class SnapshotRequest(NodeRequest):
 
 class SnapshotRequestGroup(AstacusModel):
     root_glob: str
+    # Exclude some file names that matched the glob
+    excluded_names: Sequence[str] = ()
     # None means "no limit": all files matching the glob will be embedded
     embedded_file_size_max: int | None = DEFAULT_EMBEDDED_FILE_SIZE
 

--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -90,7 +90,20 @@ class SnapshotState(AstacusModel):
 
 class SnapshotRequest(NodeRequest):
     # list of globs, e.g. ["**/*.dat"] we want to back up from root
-    root_globs: Sequence[str]
+    root_globs: Sequence[str] = ()
+
+
+class SnapshotRequestGroup(AstacusModel):
+    root_glob: str
+    # None means "no limit": all files matching the glob will be embedded
+    embedded_file_size_max: int | None = DEFAULT_EMBEDDED_FILE_SIZE
+
+
+class SnapshotRequestV2(NodeRequest):
+    # list of globs with extra options for each glob.
+    groups: Sequence[SnapshotRequestGroup] = ()
+    # Accept V1 request for backward compatibility if the controller is older
+    root_globs: Sequence[str] = ()
 
 
 class SnapshotHash(AstacusModel):

--- a/astacus/common/magic.py
+++ b/astacus/common/magic.py
@@ -10,7 +10,7 @@ ASTACUS_DEFAULT_PORT = 5515  # random port not assigned by IANA
 ASTACUS_TMPDIR = ".astacus"
 
 # Hexdigest is 32 bytes, so something orders of magnitude more at least
-EMBEDDED_FILE_SIZE = 200
+DEFAULT_EMBEDDED_FILE_SIZE = 200
 
 
 class StrEnum(str, Enum):

--- a/astacus/common/snapshot.py
+++ b/astacus/common/snapshot.py
@@ -3,6 +3,7 @@ Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from astacus.common.magic import DEFAULT_EMBEDDED_FILE_SIZE
+from typing import Sequence
 
 import dataclasses
 
@@ -10,5 +11,7 @@ import dataclasses
 @dataclasses.dataclass(frozen=True, slots=True)
 class SnapshotGroup:
     root_glob: str
+    # Exclude some file names that matched the glob
+    excluded_names: Sequence[str] = ()
     # None means "no limit": all files matching the glob will be embedded
     embedded_file_size_max: int | None = DEFAULT_EMBEDDED_FILE_SIZE

--- a/astacus/common/snapshot.py
+++ b/astacus/common/snapshot.py
@@ -1,0 +1,14 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+from astacus.common.magic import DEFAULT_EMBEDDED_FILE_SIZE
+
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SnapshotGroup:
+    root_glob: str
+    # None means "no limit": all files matching the glob will be embedded
+    embedded_file_size_max: int | None = DEFAULT_EMBEDDED_FILE_SIZE

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -91,6 +91,7 @@ class SnapshotStep(Step[List[ipc.SnapshotResult]]):
                 groups=[
                     ipc.SnapshotRequestGroup(
                         root_glob=group.root_glob,
+                        excluded_names=group.excluded_names,
                         embedded_file_size_max=group.embedded_file_size_max,
                     )
                     for group in self.snapshot_groups

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from astacus.common import exceptions, ipc, magic, utils
 from astacus.common.asyncstorage import AsyncHexDigestStorage, AsyncJsonStorage
+from astacus.common.snapshot import SnapshotGroup
 from astacus.common.utils import AstacusModel
 from astacus.coordinator.cluster import Cluster, Result
 from astacus.coordinator.config import CoordinatorNode
@@ -81,10 +82,25 @@ class SnapshotStep(Step[List[ipc.SnapshotResult]]):
     see `SnapshotFile` for details.
     """
 
-    snapshot_root_globs: Sequence[str]
+    snapshot_groups: Sequence[SnapshotGroup]
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> List[ipc.SnapshotResult]:
-        req = ipc.SnapshotRequest(root_globs=self.snapshot_root_globs)
+        nodes_metadata = await get_nodes_metadata(cluster)
+        if all(Features.snapshot_groups.value in node_metadata.features for node_metadata in nodes_metadata):
+            req: ipc.NodeRequest = ipc.SnapshotRequestV2(
+                groups=[
+                    ipc.SnapshotRequestGroup(
+                        root_glob=group.root_glob,
+                        embedded_file_size_max=group.embedded_file_size_max,
+                    )
+                    for group in self.snapshot_groups
+                ],
+            )
+        else:
+            # This is a lossy backward compatibility since the extra options are not passed
+            req = ipc.SnapshotRequest(
+                root_globs=[group.root_glob for group in self.snapshot_groups],
+            )
         start_results = await cluster.request_from_nodes("snapshot", method="post", caller="SnapshotStep", req=req)
         return await cluster.wait_successful_results(
             start_results=start_results, result_class=ipc.SnapshotResult, required_successes=len(start_results)

--- a/astacus/coordinator/plugins/clickhouse/config.py
+++ b/astacus/coordinator/plugins/clickhouse/config.py
@@ -39,6 +39,9 @@ class DiskType(enum.Enum):
 
 
 class DiskConfiguration(AstacusModel):
+    class Config:
+        use_enum_values = False
+
     type: DiskType
     path: Path
     name: str

--- a/astacus/coordinator/plugins/clickhouse/disks.py
+++ b/astacus/coordinator/plugins/clickhouse/disks.py
@@ -65,6 +65,7 @@ class DiskPaths:
         return [
             SnapshotGroup(
                 root_glob="/".join((*disk.path_parts, frozen_parts_pattern)),
+                excluded_names=("frozen_metadata.txt",) if disk.type == DiskType.object_storage else (),
                 embedded_file_size_max=None if disk.type == DiskType.object_storage else DEFAULT_EMBEDDED_FILE_SIZE,
             )
             for disk in self._disks

--- a/astacus/coordinator/plugins/clickhouse/file_metadata.py
+++ b/astacus/coordinator/plugins/clickhouse/file_metadata.py
@@ -1,0 +1,78 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+
+When using remote storage disk in ClickHouse, the actual data is in object storage
+but there are still metadata files in local storage. This module contains functions
+required to parse these metadata files.
+"""
+from pathlib import Path
+from typing import Sequence
+
+import dataclasses
+import re
+
+FILE_METADATA_RE = re.compile(
+    rb"""
+    (?P<metadata_version>3)\n
+    (?P<objects_count>\d+)\t(?P<objects_size_bytes>\d+)\n
+    (?P<objects>
+        (?:
+            \d+\t[^\n]+\n
+        )*
+    )
+    (?P<ref_count>\d+)\n
+    (?P<read_only>[01])\n$
+    """,
+    flags=re.VERBOSE,
+)
+
+OBJECT_METADATA_RE = re.compile(rb"(?P<size_bytes>\d+)\t(?P<relative_path>[^\n]+)$", flags=re.MULTILINE)
+
+
+class InvalidFileMetadata(ValueError):
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class ObjectMetadata:
+    size_bytes: int
+    relative_path: Path
+
+
+@dataclasses.dataclass(frozen=True)
+class FileMetadata:
+    metadata_version: int
+    objects: Sequence[ObjectMetadata]
+    ref_count: int
+    read_only: bool
+
+    @classmethod
+    def from_bytes(cls, content: bytes) -> "FileMetadata":
+        file_match = FILE_METADATA_RE.match(content)
+        if file_match is None:
+            raise InvalidFileMetadata(f"Invalid file metadata content: {content!r}")
+        objects_metadata = [
+            ObjectMetadata(
+                size_bytes=int(object_match.group("size_bytes")),
+                relative_path=Path(object_match.group("relative_path").decode()),
+            )
+            for object_match in OBJECT_METADATA_RE.finditer(file_match.group("objects"))
+        ]
+        expected_objects_count = int(file_match.group("objects_count"))
+        expected_objects_size = int(file_match.group("objects_size_bytes"))
+        total_objects_size = sum((object_metadata.size_bytes for object_metadata in objects_metadata))
+        if len(objects_metadata) != expected_objects_count:
+            raise InvalidFileMetadata(
+                f"Invalid file metadata objects count: expected {expected_objects_size}, got {len(objects_metadata)}"
+            )
+        if total_objects_size != expected_objects_size:
+            raise InvalidFileMetadata(
+                f"Invalid file metadata objects size: expected {expected_objects_size}, got {total_objects_size}"
+            )
+        return FileMetadata(
+            metadata_version=int(file_match.group("metadata_version")),
+            objects=objects_metadata,
+            ref_count=int(file_match.group("ref_count")),
+            read_only=file_match.group("read_only") == b"1",
+        )

--- a/astacus/coordinator/plugins/clickhouse/manifest.py
+++ b/astacus/coordinator/plugins/clickhouse/manifest.py
@@ -5,6 +5,7 @@ See LICENSE for details
 from astacus.common.utils import AstacusModel
 from astacus.coordinator.plugins.clickhouse.client import escape_sql_identifier
 from base64 import b64decode, b64encode
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from uuid import UUID
 
@@ -94,6 +95,14 @@ class ClickHouseBackupVersion(enum.Enum):
     V2 = "v2"
 
 
+class ClickHouseObjectStorageFile(AstacusModel):
+    path: Path
+
+    @classmethod
+    def from_plugin_data(cls, data: dict[str, Any]) -> "ClickHouseObjectStorageFile":
+        return ClickHouseObjectStorageFile(path=Path(data["path"]))
+
+
 class ClickHouseManifest(AstacusModel):
     class Config:
         use_enum_values = False
@@ -102,6 +111,7 @@ class ClickHouseManifest(AstacusModel):
     access_entities: List[AccessEntity] = []
     replicated_databases: List[ReplicatedDatabase] = []
     tables: List[Table] = []
+    object_storage_files: list[ClickHouseObjectStorageFile] = []
 
     def to_plugin_data(self) -> Dict[str, Any]:
         return encode_manifest_data(self.dict())
@@ -113,6 +123,9 @@ class ClickHouseManifest(AstacusModel):
             access_entities=[AccessEntity.from_plugin_data(item) for item in data["access_entities"]],
             replicated_databases=[ReplicatedDatabase.from_plugin_data(item) for item in data["replicated_databases"]],
             tables=[Table.from_plugin_data(item) for item in data["tables"]],
+            object_storage_files=[
+                ClickHouseObjectStorageFile.from_plugin_data(item) for item in data.get("object_storage_files", [])
+            ],
         )
 
 

--- a/astacus/coordinator/plugins/clickhouse/plugin.py
+++ b/astacus/coordinator/plugins/clickhouse/plugin.py
@@ -14,6 +14,7 @@ from .disks import DiskPaths
 from .steps import (
     AttachMergeTreePartsStep,
     ClickHouseManifestStep,
+    CollectObjectStorageFilesStep,
     FreezeTablesStep,
     ListDatabaseReplicasStep,
     MoveFrozenPartsStep,
@@ -108,6 +109,7 @@ class ClickHousePlugin(CoordinatorPlugin):
                 clients=clickhouse_clients, freeze_name=self.freeze_name, freeze_unfreeze_timeout=self.unfreeze_timeout
             ),
             # Prepare the manifest for restore
+            CollectObjectStorageFilesStep(disk_paths=disk_paths),
             MoveFrozenPartsStep(disk_paths=disk_paths),
             PrepareClickHouseManifestStep(),
             UploadManifestStep(

--- a/astacus/coordinator/plugins/files.py
+++ b/astacus/coordinator/plugins/files.py
@@ -28,6 +28,7 @@ from .base import (
 )
 from astacus.common import ipc
 from astacus.common.ipc import Plugin
+from astacus.common.snapshot import SnapshotGroup
 from typing import List
 
 
@@ -37,7 +38,7 @@ class FilesPlugin(CoordinatorPlugin):
 
     def get_backup_steps(self, *, context: OperationContext) -> List[Step]:
         return [
-            SnapshotStep(snapshot_root_globs=self.root_globs),
+            SnapshotStep(snapshot_groups=[SnapshotGroup(root_glob) for root_glob in self.root_globs]),
             ListHexdigestsStep(hexdigest_storage=context.hexdigest_storage),
             UploadBlocksStep(storage_name=context.storage_name),
             UploadManifestStep(json_storage=context.json_storage, plugin=Plugin.files),

--- a/astacus/coordinator/plugins/m3db.py
+++ b/astacus/coordinator/plugins/m3db.py
@@ -27,6 +27,7 @@ from .etcd import ETCDDump, ETCDKey, get_etcd_dump, restore_etcd_dump
 from astacus.common import exceptions, ipc, m3placement
 from astacus.common.etcd import ETCDClient
 from astacus.common.ipc import Plugin
+from astacus.common.snapshot import SnapshotGroup
 from astacus.common.utils import AstacusModel
 from astacus.coordinator.cluster import Cluster
 from astacus.coordinator.config import CoordinatorNode
@@ -56,7 +57,7 @@ class M3DBPlugin(CoordinatorPlugin):
         return [
             InitStep(placement_nodes=self.placement_nodes),
             RetrieveEtcdStep(etcd_client=etcd_client, etcd_prefixes=etcd_prefixes),
-            SnapshotStep(snapshot_root_globs=["**/*.db"]),
+            SnapshotStep(snapshot_groups=[SnapshotGroup(root_glob="**/*.db")]),
             ListHexdigestsStep(hexdigest_storage=context.hexdigest_storage),
             UploadBlocksStep(storage_name=context.storage_name),
             RetrieveEtcdAgainStep(etcd_client=etcd_client, etcd_prefixes=etcd_prefixes),

--- a/astacus/node/api.py
+++ b/astacus/node/api.py
@@ -31,6 +31,8 @@ class OpName(StrEnum):
 class Features(Enum):
     # Added on 2022-11-29, this can be assumed to be supported everywhere after 1 or 2 years
     validate_file_hashes = "validate_file_hashes"
+    # Added on 2023-06-07
+    snapshot_groups = "snapshot_groups"
 
 
 @router.get("/metadata")
@@ -73,7 +75,7 @@ def unlock(locker: str, state: NodeState = Depends(node_state)):
 
 
 @router.post("/snapshot")
-def snapshot(req: ipc.SnapshotRequest, n: Node = Depends()):
+def snapshot(req: ipc.SnapshotRequestV2, n: Node = Depends()):
     if not n.state.is_locked:
         raise HTTPException(status_code=409, detail="Not locked")
     return SnapshotOp(n=n, op_id=n.allocate_op_id(), stats=n.stats, req=req).start()

--- a/astacus/node/clear.py
+++ b/astacus/node/clear.py
@@ -11,6 +11,7 @@ from .node import NodeOp
 from .snapshotter import Snapshotter
 from astacus.common import ipc
 from astacus.common.progress import Progress
+from astacus.common.snapshot import SnapshotGroup
 from typing import Optional
 
 import contextlib
@@ -26,7 +27,9 @@ class ClearOp(NodeOp[ipc.SnapshotClearRequest, ipc.NodeResult]):
         return ipc.NodeResult()
 
     def start(self) -> NodeOp.StartResult:
-        self.snapshotter = self.get_or_create_snapshotter(self.req.root_globs)
+        self.snapshotter = self.get_or_create_snapshotter(
+            [SnapshotGroup(root_glob=root_glob) for root_glob in self.req.root_globs]
+        )
         logger.info("start_clear %r", self.req)
         return self.start_op(op_name="clear", op=self, fun=self.clear)
 

--- a/astacus/node/download.py
+++ b/astacus/node/download.py
@@ -14,6 +14,7 @@ from .snapshotter import Snapshotter
 from astacus.common import ipc, utils
 from astacus.common.progress import Progress
 from astacus.common.rohmustorage import RohmuStorage
+from astacus.common.snapshot import SnapshotGroup
 from astacus.common.storage import Storage, ThreadLocalStorage
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence
@@ -132,7 +133,9 @@ class DownloadOp(NodeOp[ipc.SnapshotDownloadRequest, ipc.NodeResult]):
         return ipc.NodeResult()
 
     def start(self) -> NodeOp.StartResult:
-        self.snapshotter = self.get_or_create_snapshotter(self.req.root_globs)
+        self.snapshotter = self.get_or_create_snapshotter(
+            [SnapshotGroup(root_glob=root_glob) for root_glob in self.req.root_globs]
+        )
         logger.info("start_download %r", self.req)
         return self.start_op(op_name="download", op=self, fun=self.download)
 

--- a/astacus/node/node.py
+++ b/astacus/node/node.py
@@ -9,6 +9,7 @@ from .snapshotter import Snapshotter
 from .state import node_state, NodeState
 from astacus.common import ipc, magic, op, statsd, utils
 from astacus.common.dependencies import get_request_app_state, get_request_url
+from astacus.common.snapshot import SnapshotGroup
 from astacus.common.statsd import StatsClient
 from fastapi import BackgroundTasks, Depends
 from starlette.datastructures import URL
@@ -101,12 +102,12 @@ class Node(op.OpMixin):
         self.state = state
         self.stats = stats
 
-    def get_or_create_snapshotter(self, root_globs: Sequence[str]) -> Snapshotter:
+    def get_or_create_snapshotter(self, groups: Sequence[SnapshotGroup]) -> Snapshotter:
         root_link = self.config.root_link if self.config.root_link is not None else self.config.root / magic.ASTACUS_TMPDIR
         root_link.mkdir(exist_ok=True)
 
         def _create_snapshotter() -> Snapshotter:
-            return Snapshotter(src=self.config.root, dst=root_link, globs=root_globs, parallel=self.config.parallel.hashes)
+            return Snapshotter(src=self.config.root, dst=root_link, groups=groups, parallel=self.config.parallel.hashes)
 
         return utils.get_or_create_state(state=self.app_state, key=SNAPSHOTTER_KEY, factory=_create_snapshotter)
 

--- a/astacus/node/snapshot.py
+++ b/astacus/node/snapshot.py
@@ -37,7 +37,11 @@ class SnapshotOp(NodeOp[ipc.SnapshotRequestV2, ipc.SnapshotResult]):
         # We merge the list of groups and simple root_globs
         # to handle backward compatibility if the controller is older than the nodes.
         groups = [
-            SnapshotGroup(root_glob=group.root_glob, embedded_file_size_max=group.embedded_file_size_max)
+            SnapshotGroup(
+                root_glob=group.root_glob,
+                excluded_names=group.excluded_names,
+                embedded_file_size_max=group.embedded_file_size_max,
+            )
             for group in self.req.groups
         ]
         groups += [

--- a/astacus/node/snapshotter.py
+++ b/astacus/node/snapshotter.py
@@ -227,7 +227,7 @@ class Snapshotter:
         def _cb(snapshotfile: SnapshotFile) -> SnapshotFile:
             # src may or may not be present; dst is present as it is in snapshot
             with snapshotfile.open_for_reading(self.dst) as f:
-                if snapshotfile.file_size <= magic.EMBEDDED_FILE_SIZE:
+                if snapshotfile.file_size <= magic.DEFAULT_EMBEDDED_FILE_SIZE:
                     snapshotfile.content_b64 = base64.b64encode(f.read()).decode()
                 else:
                     snapshotfile.hexdigest = hash_hexdigest_readable(f)

--- a/astacus/node/snapshotter.py
+++ b/astacus/node/snapshotter.py
@@ -8,10 +8,12 @@ See LICENSE for details
 from astacus.common import magic, utils
 from astacus.common.ipc import SnapshotFile, SnapshotHash, SnapshotState
 from astacus.common.progress import increase_worth_reporting, Progress
+from astacus.common.snapshot import SnapshotGroup
 from pathlib import Path
-from typing import Iterator, Sequence
+from typing import Iterator, Mapping, Sequence
 
 import base64
+import dataclasses
 import hashlib
 import logging
 import os
@@ -30,6 +32,12 @@ def hash_hexdigest_readable(f, *, read_buffer: int = 1_000_000) -> str:
             break
         h.update(data)
     return h.hexdigest()
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FoundFile:
+    relative_path: Path
+    group: SnapshotGroup
 
 
 class Snapshotter:
@@ -53,20 +61,20 @@ class Snapshotter:
     state during public API calls.
     """
 
-    def __init__(self, *, src: Path, dst: Path, globs: Sequence[str], parallel: int) -> None:
-        assert globs  # model has empty; either plugin or configuration must supply them
-        self.src = Path(src)
-        self.dst = Path(dst)
-        self.globs = globs
+    def __init__(self, *, src: Path, dst: Path, groups: Sequence[SnapshotGroup], parallel: int) -> None:
+        assert groups  # model has empty; either plugin or configuration must supply them
+        self.src = src
+        self.dst = dst
+        self.groups = groups
         self.relative_path_to_snapshotfile: dict[Path, SnapshotFile] = {}
         self.hexdigest_to_snapshotfiles: dict[str, list[SnapshotFile]] = {}
         self.parallel = parallel
         self.lock = threading.Lock()
 
-    def _list_files(self, basepath: Path) -> list[Path]:
+    def _list_files(self, basepath: Path) -> list[FoundFile]:
         result_files = set()
-        for glob in self.globs:
-            for path in basepath.glob(glob):
+        for group in self.groups:
+            for path in basepath.glob(group.root_glob):
                 if not path.is_file() or path.is_symlink():
                     continue
                 relpath = path.relative_to(basepath)
@@ -74,12 +82,19 @@ class Snapshotter:
                     if parent.name == magic.ASTACUS_TMPDIR:
                         break
                 else:
-                    result_files.add(relpath)
-        return sorted(result_files)
+                    result_files.add(
+                        FoundFile(
+                            relative_path=relpath,
+                            group=SnapshotGroup(
+                                root_glob=group.root_glob, embedded_file_size_max=group.embedded_file_size_max
+                            ),
+                        )
+                    )
+        return sorted(result_files, key=lambda found_file: found_file.relative_path)
 
-    def _list_dirs_and_files(self, basepath: Path) -> tuple[list[Path], list[Path]]:
+    def _list_dirs_and_files(self, basepath: Path) -> tuple[list[Path], list[FoundFile]]:
         files = self._list_files(basepath)
-        dirs = {p.parent for p in files}
+        dirs = {p.relative_path.parent for p in files}
         return sorted(dirs), files
 
     def _add_snapshotfile(self, snapshotfile: SnapshotFile) -> None:
@@ -101,24 +116,26 @@ class Snapshotter:
         st = src_path.stat()
         return SnapshotFile(relative_path=relative_path, mtime_ns=st.st_mtime_ns, file_size=st.st_size)
 
-    def _get_snapshot_hash_list(self, relative_paths: Sequence[Path]) -> Iterator[SnapshotFile]:
+    def _get_snapshot_hash_list(self, found_files: Sequence[FoundFile]) -> Iterator[SnapshotFile]:
         same = 0
         lost = 0
-        for relative_path in relative_paths:
-            old_snapshotfile = self.relative_path_to_snapshotfile.get(relative_path)
+        for found_file in found_files:
+            old_snapshotfile = self.relative_path_to_snapshotfile.get(found_file.relative_path)
             try:
-                new_snapshotfile = self._snapshotfile_from_path(relative_path)
+                new_snapshotfile = self._snapshotfile_from_path(found_file.relative_path)
             except FileNotFoundError:
                 lost += 1
                 if increase_worth_reporting(lost):
-                    logger.info("#%d. lost - %s disappeared before stat, ignoring", lost, self.src / relative_path)
+                    logger.info(
+                        "#%d. lost - %s disappeared before stat, ignoring", lost, self.src / found_file.relative_path
+                    )
                 continue
             if old_snapshotfile and old_snapshotfile.underlying_file_is_the_same(new_snapshotfile):
                 new_snapshotfile.hexdigest = old_snapshotfile.hexdigest
                 new_snapshotfile.content_b64 = old_snapshotfile.content_b64
                 same += 1
                 if increase_worth_reporting(same):
-                    logger.info("#%d. same - %r in %s is same", same, old_snapshotfile, relative_path)
+                    logger.info("#%d. same - %r in %s is same", same, old_snapshotfile, found_file.relative_path)
                 continue
 
             yield new_snapshotfile
@@ -131,7 +148,9 @@ class Snapshotter:
 
     def get_snapshot_state(self) -> SnapshotState:
         assert self.lock.locked()
-        return SnapshotState(root_globs=self.globs, files=sorted(self.relative_path_to_snapshotfile.values()))
+        return SnapshotState(
+            root_globs=[group.root_glob for group in self.groups], files=sorted(self.relative_path_to_snapshotfile.values())
+        )
 
     def _snapshot_create_missing_directories(self, *, src_dirs: Sequence[Path], dst_dirs: Sequence[Path]) -> int:
         changes = 0
@@ -143,26 +162,26 @@ class Snapshotter:
             changes += 1
         return changes
 
-    def _snapshot_remove_extra_files(self, *, src_files: Sequence[Path], dst_files: Sequence[Path]) -> int:
+    def _snapshot_remove_extra_files(self, *, src_files: Sequence[FoundFile], dst_files: Sequence[FoundFile]) -> int:
         changes = 0
-        for i, relative_path in enumerate(set(dst_files).difference(src_files), start=1):
-            dst_path = self.dst / relative_path
-            snapshotfile = self.relative_path_to_snapshotfile.get(relative_path)
+        for i, found_file in enumerate(set(dst_files).difference(src_files), start=1):
+            dst_path = self.dst / found_file.relative_path
+            snapshotfile = self.relative_path_to_snapshotfile.get(found_file.relative_path)
             if snapshotfile:
                 self._remove_snapshotfile(snapshotfile)
             dst_path.unlink()
             if increase_worth_reporting(i):
-                logger.info("#%d. extra file: %r", i, relative_path)
+                logger.info("#%d. extra file: %r", i, found_file.relative_path)
             changes += 1
         return changes
 
-    def _snapshot_add_missing_files(self, *, src_files: Sequence[Path], dst_files: Sequence[Path]) -> int:
+    def _snapshot_add_missing_files(self, *, src_files: Sequence[FoundFile], dst_files: Sequence[FoundFile]) -> int:
         existing = 0
         disappeared = 0
         changes = 0
-        for i, relative_path in enumerate(set(src_files).difference(dst_files), start=1):
-            src_path = self.src / relative_path
-            dst_path = self.dst / relative_path
+        for i, found_file in enumerate(set(src_files).difference(dst_files), start=1):
+            src_path = self.src / found_file.relative_path
+            dst_path = self.dst / found_file.relative_path
             try:
                 os.link(src=src_path, dst=dst_path, follow_symlinks=False)
             except FileExistsError:
@@ -180,7 +199,7 @@ class Snapshotter:
                     logger.info("#%d. %s disappeared before linking, ignoring", disappeared, src_path)
                 continue
             if increase_worth_reporting(i - disappeared):
-                logger.info("#%d. new file: %r", i - disappeared, relative_path)
+                logger.info("#%d. new file: %r", i - disappeared, found_file.relative_path)
             changes += 1
         return changes
 
@@ -223,11 +242,13 @@ class Snapshotter:
 
         snapshotfiles = list(self._get_snapshot_hash_list(dst_files))
         progress.add_total(len(snapshotfiles))
+        path_to_group: Mapping[Path, SnapshotGroup] = {dst_file.relative_path: dst_file.group for dst_file in dst_files}
 
         def _cb(snapshotfile: SnapshotFile) -> SnapshotFile:
             # src may or may not be present; dst is present as it is in snapshot
             with snapshotfile.open_for_reading(self.dst) as f:
-                if snapshotfile.file_size <= magic.DEFAULT_EMBEDDED_FILE_SIZE:
+                group = path_to_group[snapshotfile.relative_path]
+                if group.embedded_file_size_max is None or snapshotfile.file_size <= group.embedded_file_size_max:
                     snapshotfile.content_b64 = base64.b64encode(f.read()).decode()
                 else:
                     snapshotfile.hexdigest = hash_hexdigest_readable(f)

--- a/astacus/node/snapshotter.py
+++ b/astacus/node/snapshotter.py
@@ -77,6 +77,8 @@ class Snapshotter:
             for path in basepath.glob(group.root_glob):
                 if not path.is_file() or path.is_symlink():
                     continue
+                if path.name in group.excluded_names:
+                    continue
                 relpath = path.relative_to(basepath)
                 for parent in relpath.parents:
                     if parent.name == magic.ASTACUS_TMPDIR:

--- a/tests/integration/coordinator/plugins/clickhouse/test_file_metadata.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_file_metadata.py
@@ -1,0 +1,64 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+from astacus.coordinator.plugins.clickhouse.file_metadata import FileMetadata, InvalidFileMetadata, ObjectMetadata
+from pathlib import Path
+
+import pytest
+
+
+def test_file_metadata_from_bytes() -> None:
+    expected = FileMetadata(
+        metadata_version=3,
+        objects=[
+            ObjectMetadata(size_bytes=100, relative_path=Path("abc/0123456789abcdef")),
+            ObjectMetadata(size_bytes=200, relative_path=Path("def/aaaaaaaaaaaaaaaa")),
+        ],
+        ref_count=1,
+        read_only=False,
+    )
+    assert (
+        FileMetadata.from_bytes(
+            b"""3
+2\t300
+100\tabc/0123456789abcdef
+200\tdef/aaaaaaaaaaaaaaaa
+1
+0
+"""
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_payload",
+    [
+        b"""4
+2\t300
+100\tabc/0123456789abcdef
+200\tdef/aaaaaaaaaaaaaaaa
+1
+0
+""",
+        b"""3
+3\t300
+100\tabc/0123456789abcdef
+200\tdef/aaaaaaaaaaaaaaaa
+1
+0
+""",
+        b"""3
+2\t600
+100\tabc/0123456789abcdef
+200\tdef/aaaaaaaaaaaaaaaa
+1
+0
+""",
+    ],
+    ids=["new_version", "bad_count", "bad_size"],
+)
+def test_file_metadata_validation(bad_payload: bytes) -> None:
+    with pytest.raises(InvalidFileMetadata):
+        FileMetadata.from_bytes(bad_payload)

--- a/tests/system/test_astacus.py
+++ b/tests/system/test_astacus.py
@@ -20,8 +20,8 @@ A1_FILES_AND_CONTENTS = [
     ("empty", ""),
     ("file1", "content1"),
     ("file2", "content2"),
-    ("big1", "foobar" * magic.EMBEDDED_FILE_SIZE),
-    ("big2", "foobar" * magic.EMBEDDED_FILE_SIZE),
+    ("big1", "foobar" * magic.DEFAULT_EMBEDDED_FILE_SIZE),
+    ("big2", "foobar" * magic.DEFAULT_EMBEDDED_FILE_SIZE),
 ]
 
 

--- a/tests/unit/coordinator/plugins/clickhouse/test_manifest.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_manifest.py
@@ -166,4 +166,5 @@ def test_clickhouse_manifest_to_plugin_data() -> None:
         "access_entities": [SERIALIZED_ACCESS_ENTITY],
         "replicated_databases": [SERIALIZED_DATABASE],
         "tables": [SERIALIZED_TABLE],
+        "object_storage_files": [],
     }

--- a/tests/unit/node/conftest.py
+++ b/tests/unit/node/conftest.py
@@ -28,8 +28,8 @@ def fixture_app(tmpdir) -> FastAPI:
     root.mkdir()
     (root / "foo").write_text("foobar")
     (root / "foo2").write_text("foobar")
-    (root / "foobig").write_text("foobar" * magic.EMBEDDED_FILE_SIZE)
-    (root / "foobig2").write_text("foobar" * magic.EMBEDDED_FILE_SIZE)
+    (root / "foobig").write_text("foobar" * magic.DEFAULT_EMBEDDED_FILE_SIZE)
+    (root / "foobig2").write_text("foobar" * magic.DEFAULT_EMBEDDED_FILE_SIZE)
     app.state.node_config = NodeConfig.parse_obj(
         {
             "az": "testaz",
@@ -59,8 +59,8 @@ class SnapshotterWithDefaults(Snapshotter):
     def create_4foobar(self):
         (self.src / "foo").write_text("foobar")
         (self.src / "foo2").write_text("foobar")
-        (self.src / "foobig").write_text("foobar" * magic.EMBEDDED_FILE_SIZE)
-        (self.src / "foobig2").write_text("foobar" * magic.EMBEDDED_FILE_SIZE)
+        (self.src / "foobig").write_text("foobar" * magic.DEFAULT_EMBEDDED_FILE_SIZE)
+        (self.src / "foobig2").write_text("foobar" * magic.DEFAULT_EMBEDDED_FILE_SIZE)
         assert self.snapshot(progress=Progress()) > 0
         ss1 = self.get_snapshot_state()
         assert self.snapshot(progress=Progress()) == 0

--- a/tests/unit/node/conftest.py
+++ b/tests/unit/node/conftest.py
@@ -8,7 +8,7 @@ from astacus.common.progress import Progress
 from astacus.common.storage import FileStorage
 from astacus.node.api import router as node_router
 from astacus.node.config import NodeConfig
-from astacus.node.snapshotter import Snapshotter
+from astacus.node.snapshotter import SnapshotGroup, Snapshotter
 from astacus.node.uploader import Uploader
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -74,7 +74,7 @@ def fixture_snapshotter(tmpdir):
     src.mkdir()
     dst = Path(tmpdir) / "dst"
     dst.mkdir()
-    yield SnapshotterWithDefaults(src=src, dst=dst, globs=["*"], parallel=1)
+    yield SnapshotterWithDefaults(src=src, dst=dst, groups=[SnapshotGroup(root_glob="*")], parallel=1)
 
 
 @pytest.fixture(name="uploader")

--- a/tests/unit/node/test_node_download.py
+++ b/tests/unit/node/test_node_download.py
@@ -6,7 +6,7 @@ See LICENSE for details
 from astacus.common import ipc, utils
 from astacus.common.progress import Progress
 from astacus.node.download import Downloader
-from astacus.node.snapshotter import Snapshotter
+from astacus.node.snapshotter import SnapshotGroup, Snapshotter
 from pathlib import Path
 
 
@@ -24,7 +24,7 @@ def test_download(snapshotter, uploader, storage, tmpdir):
 
     dst3 = Path(tmpdir / "dst3")
     dst3.mkdir()
-    snapshotter = Snapshotter(src=dst2, dst=dst3, globs=["*"], parallel=1)
+    snapshotter = Snapshotter(src=dst2, dst=dst3, groups=[SnapshotGroup(root_glob="*")], parallel=1)
     downloader = Downloader(storage=storage, snapshotter=snapshotter, dst=dst2, parallel=1)
     with snapshotter.lock:
         downloader.download_from_storage(progress=Progress(), snapshotstate=ss1)

--- a/tests/unit/node/test_node_snapshot.py
+++ b/tests/unit/node/test_node_snapshot.py
@@ -156,14 +156,14 @@ def test_api_snapshot_error(client, mocker):
 @pytest.mark.parametrize(
     "truncate_to,hashes_in_second_snapshot",
     [
-        (magic.EMBEDDED_FILE_SIZE - 1, 0),
-        (magic.EMBEDDED_FILE_SIZE + 1, 1),
+        (magic.DEFAULT_EMBEDDED_FILE_SIZE - 1, 0),
+        (magic.DEFAULT_EMBEDDED_FILE_SIZE + 1, 1),
     ],
 )
 def test_snapshot_file_size_changed(snapshotter, truncate_to, hashes_in_second_snapshot):
     path = snapshotter.src / "shrinky"
     with snapshotter.lock:
-        path.write_text("foobar" * magic.EMBEDDED_FILE_SIZE)
+        path.write_text("foobar" * magic.DEFAULT_EMBEDDED_FILE_SIZE)
         assert snapshotter.snapshot(progress=Progress()) > 0
 
         os.truncate(path, truncate_to)


### PR DESCRIPTION
After collecting metadata files of files in object storage, extract
the path of the remote files.

This required an extension of the snapshot protocol to have
different option for each glob.