### PR TITLE
specfile: add snappy dependency

### DIFF
--- a/astacus.spec
+++ b/astacus.spec
@@ -17,6 +17,7 @@ BuildRequires:  python3-chardet
 BuildRequires:  python3-devel
 BuildRequires:  python3-pip
 BuildRequires:  python3-wheel
+BuildRequires:  snappy-devel
 BuildRequires:  which
 
 # These are used when actually running the package


### PR DESCRIPTION
We need snappy as a transitive dependency for rohmu; it was missing in
Fedora build-dep.
