### PR TITLE
clickhouse: garbage collect object storage files

### DIFF
--- a/astacus/coordinator/api.py
+++ b/astacus/coordinator/api.py
@@ -115,7 +115,7 @@ async def _list_backups(*, req: ipc.ListRequest = ipc.ListRequest(), c: Coordina
 
 
 @router.post("/cleanup")
-async def cleanup(*, op: CleanupOp = Depends(), c: Coordinator = Depends()):
+async def cleanup(*, op: CleanupOp = Depends(CleanupOp.create), c: Coordinator = Depends()):
     runner = await op.acquire_cluster_lock()
     return c.start_op(op_name=OpName.cleanup, op=op, fun=runner)
 

--- a/astacus/coordinator/cleanup.py
+++ b/astacus/coordinator/cleanup.py
@@ -6,10 +6,8 @@ Database cleanup operation
 
 """
 
-from astacus.common import ipc, magic, utils
-from astacus.coordinator.cluster import Cluster
-from astacus.coordinator.coordinator import Coordinator, LockedCoordinatorOp
-from astacus.coordinator.manifest import download_backup_manifest
+from astacus.common import ipc
+from astacus.coordinator.coordinator import Coordinator, SteppedCoordinatorOp
 from fastapi import Depends
 
 import logging
@@ -17,92 +15,17 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class CleanupOp(LockedCoordinatorOp):
-    def __init__(self, *, c: Coordinator = Depends(), req: ipc.CleanupRequest = ipc.CleanupRequest()):
-        super().__init__(c=c)
-        self.req = req
-        self.retention = c.config.retention
-        self.context = c.get_operation_context(requested_storage=req.storage)
+class CleanupOp(SteppedCoordinatorOp):
+    @staticmethod
+    async def create(*, c: Coordinator = Depends(), req: ipc.CleanupRequest = ipc.CleanupRequest()) -> "CleanupOp":
+        return CleanupOp(c=c, req=req)
 
-    async def run_with_lock(self, cluster: Cluster) -> None:
-        retention = self.retention.copy()
-        if self.req.retention is not None:
+    def __init__(self, *, c: Coordinator, req: ipc.CleanupRequest) -> None:
+        context = c.get_operation_context()
+        retention = c.config.retention.copy()
+        if req.retention is not None:
             # This returns only non-defaults -> non-Nones
-            for k, v in self.req.retention.dict().items():
+            for k, v in req.retention.dict().items():
                 setattr(retention, k, v)
-        all_backups = await self._list_backups()
-        kept_backups = all_backups.difference(set(self.req.explicit_delete))
-        kept_backups = await self.determine_kept_backups(retention=retention, backups=kept_backups)
-        await self.delete_backups(all_backups.difference(kept_backups))
-
-    async def _list_backups(self):
-        return set(b for b in await self.context.json_storage.list_jsons() if b.startswith(magic.JSON_BACKUP_PREFIX))
-
-    async def _download_backup_manifests(self, backups):
-        for backup in backups:
-            yield await download_backup_manifest(self.context.json_storage, backup)
-
-    async def delete_backups(self, backups):
-        if not backups:
-            logger.debug("delete_backups: nothing to delete")
-            return
-        for backup in backups:
-            logger.info("deleting backup %r", backup)
-            await self.context.json_storage.delete_json(backup)
-        await self.delete_dangling_hexdigests()
-
-    async def delete_dangling_hexdigests(self):
-        logger.info("delete_dangling_hexdigests - downloading backup list")
-        backups = await self._list_backups()
-        logger.info("downloading backup manifests")
-        kept_hexdigests = set()
-
-        async for manifest in self._download_backup_manifests(backups):
-            for result in manifest.snapshot_results:
-                assert result.hashes is not None
-                kept_hexdigests = kept_hexdigests | set(h.hexdigest for h in result.hashes if h.hexdigest)
-
-        all_hexdigests = await self.context.hexdigest_storage.list_hexdigests()
-        extra_hexdigests = set(all_hexdigests).difference(kept_hexdigests)
-        if not extra_hexdigests:
-            return
-        logger.info("deleting %d hexdigests from object storage", len(extra_hexdigests))
-        for i, hexdigest in enumerate(extra_hexdigests, 1):
-            # Due to rate limiting, it might be better to not do this in parallel
-            await self.context.hexdigest_storage.delete_hexdigest(hexdigest)
-            if i % 100 == 0:
-                self.stats.gauge("astacus_cleanup_hexdigest_progress", i)
-                self.stats.gauge("astacus_cleanup_hexdigest_progress_percent", 100.0 * i / len(extra_hexdigests))
-
-    async def determine_kept_backups(self, *, retention, backups):
-        if retention.minimum_backups is not None and retention.minimum_backups >= len(backups):
-            return backups
-        now = utils.now()
-
-        aux = []
-        async for m in self._download_backup_manifests(backups):
-            aux.append((m.start, m.end, m.filename))
-
-        manifests = sorted(aux, reverse=True)
-        while manifests:
-            if retention.maximum_backups is not None:
-                if retention.maximum_backups < len(manifests):
-                    manifests.pop()
-                    continue
-
-            # Ok, so now we have at most <maximum_backups> (if set) backups
-
-            # Do we have too _few_ backups to delete any more?
-            if retention.minimum_backups is not None:
-                if retention.minimum_backups >= len(manifests):
-                    break
-
-            if retention.keep_days is not None:
-                manifest = manifests[-1]
-                if (now - manifest[1]).days > retention.keep_days:
-                    manifests.pop()
-                    continue
-            # We don't have any other criteria to filter the backup manifests with
-            break
-
-        return set(manifest[2] for manifest in manifests)
+        steps = c.get_plugin().get_cleanup_steps(context=context, retention=retention, explicit_delete=req.explicit_delete)
+        super().__init__(c=c, attempts=1, steps=steps)

--- a/astacus/coordinator/plugins/clickhouse/async_object_storage.py
+++ b/astacus/coordinator/plugins/clickhouse/async_object_storage.py
@@ -1,0 +1,75 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+from abc import ABC, abstractmethod
+from pathlib import Path
+from rohmu.errors import FileNotFoundFromStorageError
+from starlette.concurrency import run_in_threadpool
+from typing import Any, Mapping
+
+import dataclasses
+import datetime
+import logging
+import rohmu
+import threading
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class ObjectStorageItem:
+    key: Path
+    last_modified: datetime.datetime
+
+
+class AsyncObjectStorage(ABC):
+    @abstractmethod
+    async def list_items(self) -> list[ObjectStorageItem]:
+        ...
+
+    @abstractmethod
+    async def delete_item(self, key: Path) -> None:
+        ...
+
+
+class ThreadSafeRohmuStorage:
+    def __init__(self, config: Mapping[str, Any]) -> None:
+        self._storage = rohmu.get_transfer(config)
+        self._storage_lock = threading.Lock()
+
+    def list_iter(self, key: str, *, with_metadata: bool = True, deep: bool = False) -> list[Mapping[str, Any]]:
+        with self._storage_lock:
+            return self._storage.list_iter(key, with_metadata=with_metadata, deep=deep)
+
+    def delete_key(self, key: str) -> None:
+        with self._storage_lock:
+            self._storage.delete_key(key)
+
+
+@dataclasses.dataclass(frozen=True)
+class RohmuAsyncObjectStorage(AsyncObjectStorage):
+    storage: ThreadSafeRohmuStorage
+
+    async def list_items(self) -> list[ObjectStorageItem]:
+        items = await run_in_threadpool(self.storage.list_iter, key="", with_metadata=True, deep=True)
+        return [ObjectStorageItem(key=Path(item["name"]), last_modified=item["last_modified"]) for item in items]
+
+    async def delete_item(self, key: Path) -> None:
+        await run_in_threadpool(self.storage.delete_key, str(key))
+
+
+@dataclasses.dataclass(frozen=True)
+class MemoryAsyncObjectStorage(AsyncObjectStorage):
+    items: list[ObjectStorageItem]
+
+    async def list_items(self) -> list[ObjectStorageItem]:
+        return self.items[:]
+
+    async def delete_item(self, key: Path) -> None:
+        for item in self.items:
+            if item.key == key:
+                logger.info("deleting item: %r", key)
+                self.items.remove(item)
+                return
+        raise FileNotFoundFromStorageError(key)

--- a/astacus/coordinator/plugins/clickhouse/config.py
+++ b/astacus/coordinator/plugins/clickhouse/config.py
@@ -3,6 +3,7 @@ Copyright (c) 2021 Aiven Ltd
 See LICENSE for details
 """
 from .client import ClickHouseClient, HttpClickHouseClient
+from astacus.common.rohmustorage import RohmuStorageConfig
 from astacus.common.utils import AstacusModel, build_netloc
 from astacus.coordinator.plugins.zookeeper import KazooZooKeeperClient, ZooKeeperClient
 from astacus.coordinator.plugins.zookeeper_config import ZooKeeperConfiguration
@@ -38,6 +39,11 @@ class DiskType(enum.Enum):
     object_storage = "object_storage"
 
 
+class DiskObjectStorageConfiguration(AstacusModel):
+    default_storage: str
+    storages: dict[str, RohmuStorageConfig]
+
+
 class DiskConfiguration(AstacusModel):
     class Config:
         use_enum_values = False
@@ -45,6 +51,7 @@ class DiskConfiguration(AstacusModel):
     type: DiskType
     path: Path
     name: str
+    object_storage: Optional[DiskObjectStorageConfiguration] = None
 
 
 def get_zookeeper_client(configuration: ZooKeeperConfiguration) -> ZooKeeperClient:

--- a/astacus/coordinator/plugins/clickhouse/manifest.py
+++ b/astacus/coordinator/plugins/clickhouse/manifest.py
@@ -103,6 +103,18 @@ class ClickHouseObjectStorageFile(AstacusModel):
         return ClickHouseObjectStorageFile(path=Path(data["path"]))
 
 
+class ClickHouseObjectStorageFiles(AstacusModel):
+    disk_name: str
+    files: list[ClickHouseObjectStorageFile]
+
+    @classmethod
+    def from_plugin_data(cls, data: dict[str, Any]) -> "ClickHouseObjectStorageFiles":
+        return ClickHouseObjectStorageFiles(
+            disk_name=data["disk_name"],
+            files=[ClickHouseObjectStorageFile.from_plugin_data(item) for item in data["files"]],
+        )
+
+
 class ClickHouseManifest(AstacusModel):
     class Config:
         use_enum_values = False
@@ -111,7 +123,7 @@ class ClickHouseManifest(AstacusModel):
     access_entities: List[AccessEntity] = []
     replicated_databases: List[ReplicatedDatabase] = []
     tables: List[Table] = []
-    object_storage_files: list[ClickHouseObjectStorageFile] = []
+    object_storage_files: list[ClickHouseObjectStorageFiles] = []
 
     def to_plugin_data(self) -> Dict[str, Any]:
         return encode_manifest_data(self.dict())
@@ -124,7 +136,7 @@ class ClickHouseManifest(AstacusModel):
             replicated_databases=[ReplicatedDatabase.from_plugin_data(item) for item in data["replicated_databases"]],
             tables=[Table.from_plugin_data(item) for item in data["tables"]],
             object_storage_files=[
-                ClickHouseObjectStorageFile.from_plugin_data(item) for item in data.get("object_storage_files", [])
+                ClickHouseObjectStorageFiles.from_plugin_data(item) for item in data.get("object_storage_files", [])
             ],
         )
 

--- a/tests/unit/coordinator/plugins/clickhouse/test_disks.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_disks.py
@@ -22,7 +22,7 @@ def test_parse_part_file_path() -> None:
         Path("store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")
     )
     assert parsed_path == ParsedPath(
-        disk=Disk(type=DiskType.local, path_parts=()),
+        disk=Disk(type=DiskType.local, name="default", path_parts=()),
         freeze_name=None,
         table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
         detached=False,
@@ -37,7 +37,7 @@ def test_parse_detached_part_file_path() -> None:
         Path("store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt")
     )
     assert parsed_path == ParsedPath(
-        disk=Disk(type=DiskType.local, path_parts=()),
+        disk=Disk(type=DiskType.local, name="default", path_parts=()),
         freeze_name=None,
         table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
         detached=True,
@@ -52,7 +52,7 @@ def test_parse_shadow_part_file_path() -> None:
         Path("shadow/astacus/store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt")
     )
     assert parsed_path == ParsedPath(
-        disk=Disk(type=DiskType.local, path_parts=()),
+        disk=Disk(type=DiskType.local, name="default", path_parts=()),
         freeze_name=b"astacus",
         table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
         detached=True,
@@ -72,7 +72,7 @@ def test_parse_part_file_path_on_other_disk() -> None:
         Path("disks/secondary/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")
     )
     assert parsed_path == ParsedPath(
-        disk=Disk(type=DiskType.object_storage, path_parts=("disks", "secondary")),
+        disk=Disk(type=DiskType.object_storage, name="secondary", path_parts=("disks", "secondary")),
         freeze_name=None,
         table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
         detached=False,
@@ -83,7 +83,7 @@ def test_parse_part_file_path_on_other_disk() -> None:
 
 def test_parsed_path_to_path() -> None:
     assert ParsedPath(
-        disk=Disk(type=DiskType.local, path_parts=()),
+        disk=Disk(type=DiskType.local, name="default", path_parts=()),
         freeze_name=None,
         table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
         detached=False,
@@ -94,7 +94,7 @@ def test_parsed_path_to_path() -> None:
 
 def test_detached_parsed_path_to_path() -> None:
     assert ParsedPath(
-        disk=Disk(type=DiskType.local, path_parts=()),
+        disk=Disk(type=DiskType.local, name="default", path_parts=()),
         freeze_name=None,
         table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
         detached=True,
@@ -105,7 +105,7 @@ def test_detached_parsed_path_to_path() -> None:
 
 def test_shadow_parsed_path_to_path() -> None:
     assert ParsedPath(
-        disk=Disk(type=DiskType.local, path_parts=()),
+        disk=Disk(type=DiskType.local, name="default", path_parts=()),
         freeze_name=b"this/is\x80weird",
         table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
         detached=False,
@@ -116,7 +116,7 @@ def test_shadow_parsed_path_to_path() -> None:
 
 def test_other_disk_parsed_path_to_path() -> None:
     assert ParsedPath(
-        disk=Disk(type=DiskType.object_storage, path_parts=("disks", "secondary")),
+        disk=Disk(type=DiskType.object_storage, name="secondary", path_parts=("disks", "secondary")),
         freeze_name=None,
         table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
         detached=False,

--- a/tests/unit/coordinator/test_cleanup.py
+++ b/tests/unit/coordinator/test_cleanup.py
@@ -62,10 +62,10 @@ def test_api_cleanup_flow(fail_at, client, populated_mstorage, app):
         (ipc.Retention(maximum_backups=1), 1, 1),
         (ipc.Retention(keep_days=-1), 0, 0),
         (ipc.Retention(minimum_backups=1, keep_days=-1), 1, 1),
-        (ipc.Retention(minimum_backups=3, maximum_backups=1, keep_days=-1), 2, 2),
+        (ipc.Retention(minimum_backups=3, maximum_backups=1, keep_days=-1), 2, 1),
         (ipc.Retention(keep_days=100), 0, 0),
-        (ipc.Retention(keep_days=10000), 2, 2),
-        (ipc.Retention(minimum_backups=1, keep_days=10000), 2, 2),
+        (ipc.Retention(keep_days=10000), 2, 1),
+        (ipc.Retention(minimum_backups=1, keep_days=10000), 2, 1),
         (ipc.Retention(maximum_backups=1, keep_days=10000), 1, 1),
     ],
 )

--- a/tests/unit/json_storage.py
+++ b/tests/unit/json_storage.py
@@ -1,0 +1,35 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+from astacus.common import exceptions
+from astacus.common.storage import Json, JsonStorage
+
+import dataclasses
+import json
+
+
+@dataclasses.dataclass(frozen=True)
+class MemoryJsonStorage(JsonStorage):
+    items: dict[str, str]
+
+    def delete_json(self, name: str) -> None:
+        try:
+            del self.items[name]
+        except KeyError as e:
+            raise exceptions.NotFoundException from e
+
+    def download_json(self, name: str) -> Json:
+        try:
+            data = self.items[name]
+        except KeyError as e:
+            raise exceptions.NotFoundException from e
+        else:
+            return json.loads(data)
+
+    def list_jsons(self) -> list[str]:
+        return sorted(self.items)
+
+    def upload_json_str(self, name: str, data: str) -> bool:
+        self.items[name] = data
+        return True


### PR DESCRIPTION
Files in object storage that are older than the start time of the
newest backup and not part of any backup are now removed
during the cleanup operation.

If there are no backup, there are no files older than the newest
backup, so we do nothing.

[DDB-213]

[DDB-213]: https://aiven.atlassian.net/browse/DDB-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ