### PR TITLE
node: handle mode and owner of downloaded files

### DIFF
--- a/astacus/node/config.py
+++ b/astacus/node/config.py
@@ -60,6 +60,11 @@ class NodeConfig(AstacusModel):
 
     parallel: NodeParallel = Field(default_factory=NodeParallel)
 
+    # Copy the owner of created files and folders from the owner of root,
+    # this requires the right to run this command:
+    # /usr/bin/sudo /usr/bin/chown --from=astacus_username:data_root_gid data_root_uid -- FILE...
+    copy_root_owner: bool = False
+
     # Cassandra configuration is optional; for now, in node part of
     # the code, there are no plugins. (This may change later.)
     cassandra: Optional[CassandraNodeConfig]

--- a/astacus/node/download.py
+++ b/astacus/node/download.py
@@ -16,6 +16,7 @@ from astacus.common.progress import Progress
 from astacus.common.rohmustorage import RohmuStorage
 from astacus.common.snapshot import SnapshotGroup
 from astacus.common.storage import Storage, ThreadLocalStorage
+from astacus.common.utils import get_umask
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence
 
@@ -52,6 +53,7 @@ class Downloader(ThreadLocalStorage):
             else:
                 assert snapshotfile.content_b64 is not None
                 f.write(base64.b64decode(snapshotfile.content_b64))
+        os.chmod(download_path, 0o660 & ~get_umask())
         os.utime(download_path, ns=(snapshotfile.mtime_ns, snapshotfile.mtime_ns))
 
     def _download_snapshotfiles_from_storage(self, snapshotfiles: Sequence[ipc.SnapshotFile]) -> None:

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -7,7 +7,7 @@ Test astacus.common.utils
 """
 
 from astacus.common import utils
-from astacus.common.utils import AsyncSleeper, build_netloc
+from astacus.common.utils import AsyncSleeper, build_netloc, parse_umask
 from datetime import timedelta
 from pathlib import Path
 
@@ -174,3 +174,19 @@ def test_open_path_with_atomic_rename(tmpdir):
         with utils.open_path_with_atomic_rename(f3_path):
             assert False
     assert not Path(f3_path).exists()
+
+
+def test_parse_umask() -> None:
+    proc_status = """Name:   cat
+Umask:  0027
+State:  R (running)
+"""
+    assert parse_umask(proc_status) == 0o027
+
+
+def test_parse_umask_fallback() -> None:
+    proc_status = """Name:   cat
+Umask:  POTATO
+State:  R (running)
+"""
+    assert parse_umask(proc_status) == 0o022


### PR DESCRIPTION
The goal is to be able to user a restored data dir when astacus and the restored service run
with a different user (but a shared group).

The first part is restoring less restricting file modes that are injected by `NamedTemporaryFile`
to enable read/write by the group on restored files.

The second part is more painful: despite having access to the restored files through the group
permission, some services also do file operations that require being the exact owner of the file.

This requires chowning the file, which cannot be done by the astacus or the service user.

This is solved by using sudo for the chown, and giving the sudo command a recognizable and
restricted shape that is suitable for sudoers directives.