### PR TITLE
deps: update rohmu models for the latest version

### DIFF
--- a/astacus/common/rohmustorage.py
+++ b/astacus/common/rohmustorage.py
@@ -12,7 +12,7 @@ from .storage import Json, MultiStorage, Storage, StorageUploadResult
 from .utils import AstacusModel
 from astacus.common import exceptions
 from enum import Enum
-from pydantic import DirectoryPath, Field
+from pydantic import Field
 from rohmu import errors, rohmufile
 from typing import BinaryIO, Dict, Optional, Union
 from typing_extensions import Literal
@@ -58,15 +58,33 @@ class RohmuProxyInfo(RohmuModel):
     password: Optional[str] = Field(None, alias="pass")
 
 
-class RohmuProxyStorage(RohmuModel):
+class StatsdInfo(RohmuModel):
+    host: str
+    port: int
+    tags: dict[str, str | int | None]
+
+
+class ObjectStorageNotifier(RohmuModel):
+    notifier_type: str
+    url: str
+
+
+class ObjectStorageConfig(RohmuModel):
+    storage_type: RohmuStorageType
+    prefix: Optional[str] = None
+    notifier: Optional[ObjectStorageNotifier] = None
+    statsd_info: Optional[StatsdInfo] = None
+
+
+class RohmuProxyStorage(ObjectStorageConfig):
     """Storage backend with support for optional socks5 or http proxy connections"""
 
     proxy_info: Optional[RohmuProxyInfo] = None
 
 
-class RohmuLocalStorageConfig(RohmuModel):
+class RohmuLocalStorageConfig(ObjectStorageConfig):
     storage_type: Literal[RohmuStorageType.local]
-    directory: DirectoryPath
+    directory: str
     prefix: Optional[str] = None
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ install_requires =
   fastapi==0.86.0
   httpx==0.22.0
   protobuf==3.19.4
-  rohmu==1.0.7
+  rohmu==1.1.0
   sentry-sdk==1.6.0
   tabulate==0.9.0
   typing-extensions==4.4.0

--- a/tests/integration/coordinator/plugins/clickhouse/conftest.py
+++ b/tests/integration/coordinator/plugins/clickhouse/conftest.py
@@ -535,7 +535,7 @@ def create_astacus_configs(
                 storages={
                     "test": RohmuLocalStorageConfig(
                         storage_type=RohmuStorageType.local,
-                        directory=astacus_backup_storage_path,
+                        directory=str(astacus_backup_storage_path),
                     )
                 },
                 compression=RohmuCompression(algorithm=RohmuCompressionType.zstd),


### PR DESCRIPTION
The incomplete models and type mismatch were causing integration failures with the latest rohmu.