### PR TITLE
zookeeper: add support for client authentication

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install dependencies
         run: make build-dep-ubuntu
 
-      - name: Set up Python 3.10 with caching
+      - name: Set up Python 3.11 with caching
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/astacus/coordinator/plugins/clickhouse/config.py
+++ b/astacus/coordinator/plugins/clickhouse/config.py
@@ -55,7 +55,8 @@ class DiskConfiguration(AstacusModel):
 
 
 def get_zookeeper_client(configuration: ZooKeeperConfiguration) -> ZooKeeperClient:
-    return KazooZooKeeperClient(hosts=[build_netloc(node.host, node.port) for node in configuration.nodes])
+    user = configuration.user.to_dataclass() if configuration.user else None
+    return KazooZooKeeperClient(hosts=[build_netloc(node.host, node.port) for node in configuration.nodes], user=user)
 
 
 def get_clickhouse_clients(configuration: ClickHouseConfiguration) -> List[ClickHouseClient]:

--- a/astacus/coordinator/plugins/zookeeper_config.py
+++ b/astacus/coordinator/plugins/zookeeper_config.py
@@ -3,7 +3,8 @@ Copyright (c) 2022 Aiven Ltd
 See LICENSE for details
 """
 from astacus.common.utils import AstacusModel, build_netloc
-from astacus.coordinator.plugins.zookeeper import KazooZooKeeperClient, ZooKeeperClient
+from astacus.coordinator.plugins.zookeeper import KazooZooKeeperClient, ZooKeeperClient, ZooKeeperUser
+from pydantic import SecretStr
 from typing import List
 
 
@@ -12,9 +13,19 @@ class ZooKeeperNode(AstacusModel):
     port: int
 
 
+class ZooKeeperConfigurationUser(AstacusModel):
+    username: str
+    password: SecretStr
+
+    def to_dataclass(self) -> ZooKeeperUser:
+        return ZooKeeperUser(self.username, self.password.get_secret_value())
+
+
 class ZooKeeperConfiguration(AstacusModel):
     nodes: List[ZooKeeperNode] = []
+    user: ZooKeeperConfigurationUser | None = None
 
 
 def get_zookeeper_client(configuration: ZooKeeperConfiguration) -> ZooKeeperClient:
-    return KazooZooKeeperClient(hosts=[build_netloc(node.host, node.port) for node in configuration.nodes])
+    user = configuration.user.to_dataclass() if configuration.user else None
+    return KazooZooKeeperClient(hosts=[build_netloc(node.host, node.port) for node in configuration.nodes], user=user)

--- a/tests/integration/coordinator/plugins/clickhouse/test_zookeeper.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_zookeeper.py
@@ -126,7 +126,7 @@ async def test_kazoo_zookeeper_failing_transaction(zookeeper_client: KazooZooKee
 @pytest.mark.asyncio
 async def test_kazoo_zookeeper_client_bounded_failure_time(ports: Ports) -> None:
     async with create_zookeeper(ports) as zookeeper:
-        zookeeper_client = KazooZooKeeperClient(hosts=[get_kazoo_host(zookeeper)], timeout=1)
+        zookeeper_client = KazooZooKeeperClient(hosts=[get_kazoo_host(zookeeper)], user=None, timeout=1)
         async with zookeeper_client.connect() as connection:
             zookeeper.process.kill()
             start_time = time.monotonic()


### PR DESCRIPTION
Kazoo supports digest authentication and clients may want to authenticate their requests. Implement it for the ClickHouse plugin.