### PR TITLE
Restore schema from snapshot when doing partial restore

### DIFF
--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -196,6 +196,7 @@ class CassandraSubOp(StrEnum):
     get_schema_hash = "get-schema-hash"
     remove_snapshot = "remove-snapshot"
     restore_snapshot = "restore-snapshot"
+    restore_snapshot_with_schema = "restore-snapshot-with-schema"
     start_cassandra = "start-cassandra"
     stop_cassandra = "stop-cassandra"
     take_snapshot = "take-snapshot"

--- a/astacus/coordinator/plugins/cassandra/plugin.py
+++ b/astacus/coordinator/plugins/cassandra/plugin.py
@@ -83,14 +83,32 @@ class CassandraPlugin(CoordinatorPlugin):
         # The nodes are not really used for now; perhaps they should be, at some point?
         # their validity is checked just for symmetry with backup, for now.
         nodes = self.nodes or [CassandraConfigurationNode(listen_address=self.client.get_listen_address())]
-        client = CassandraClient(self.client)
 
-        # TBD: partial_restore_nodes should be probably passed to about all steps?
+        cluster_restore_steps = (
+            self.get_restore_schema_from_snapshot_steps(context=context, req=req)
+            if req.partial_restore_nodes
+            else self.get_restore_schema_from_manifest_steps(context=context, req=req)
+        )
+
         return [
             ValidateConfigurationStep(nodes=nodes),
             base.BackupNameStep(json_storage=context.json_storage, requested_name=req.name),
             base.BackupManifestStep(json_storage=context.json_storage),
             restore_steps.ParsePluginManifestStep(),
+        ] + cluster_restore_steps
+
+    def get_restore_schema_from_snapshot_steps(self, *, context: OperationContext, req: ipc.RestoreRequest) -> List[Step]:
+        return [
+            base.RestoreStep(storage_name=context.storage_name, partial_restore_nodes=req.partial_restore_nodes),
+            CassandraSubOpStep(op=ipc.CassandraSubOp.restore_snapshot_with_schema),
+            restore_steps.StartCassandraStep(partial_restore_nodes=req.partial_restore_nodes, override_tokens=True),
+            restore_steps.WaitCassandraUpStep(duration=self.restore_start_timeout),
+        ]
+
+    def get_restore_schema_from_manifest_steps(self, *, context: OperationContext, req: ipc.RestoreRequest) -> List[Step]:
+        client = CassandraClient(self.client)
+
+        return [
             # Start cassandra with backed up token distribution + set schema + stop it
             restore_steps.StartCassandraStep(partial_restore_nodes=req.partial_restore_nodes, override_tokens=True),
             restore_steps.WaitCassandraUpStep(duration=self.restore_start_timeout),

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -49,6 +49,10 @@ class CassandraTestConfig:
         self.snapshot_path = keyspace_path / "dummytable-123" / "snapshots" / SNAPSHOT_NAME
         self.snapshot_path.mkdir(parents=True)
 
+        system_schema_path = self.root / "data" / "system_schema" / "tables-789" / "snapshots" / SNAPSHOT_NAME
+        system_schema_path.mkdir(parents=True)
+        (system_schema_path / "data.file").write_text("schema")
+
         self.other_snapshot_path = keyspace_path / "dummytable-123" / "snapshots" / f"not{SNAPSHOT_NAME}"
         self.other_snapshot_path.mkdir(parents=True)
 

--- a/tests/unit/node/test_node_cassandra.py
+++ b/tests/unit/node/test_node_cassandra.py
@@ -94,6 +94,15 @@ def test_api_cassandra_subop(app, ctenv, mocker, subop):
         # dummytable-234
         assert (ctenv.root / "data" / "dummyks" / "dummytable-234" / "asdf").read_text() == "foobar"
         assert progress["handled"]
+        # System schema keyspace should not be transferred
+        assert not (ctenv.root / "data" / "system_schema" / "tables-789" / "data.file").exists()
+    elif subop == ipc.CassandraSubOp.restore_snapshot_with_schema:
+        # The file should be moved from dummytable-123 snapshot dir to
+        # dummytable-123
+        assert (ctenv.root / "data" / "dummyks" / "dummytable-123" / "asdf").read_text() == "foobar"
+        assert progress["handled"]
+        # System schema keyspace should be restored
+        assert (ctenv.root / "data" / "system_schema" / "tables-789" / "data.file").read_text() == "schema"
     elif subop == ipc.CassandraSubOp.start_cassandra:
         subprocess_run.assert_any_call(ctenv.cassandra_node_config.start_command + ["tempfilename"], check=True)
 


### PR DESCRIPTION
When doing partial restore, we already have a live cluster, therefore
we cannot (and do not need to) re-create schema from the manifest.
Restore it from system_schema. This way we keep table ids and can
avoid matching table data directories by table name.