### PR TITLE
Implement basic partial restore for Cassandra

### DIFF
--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -204,6 +204,8 @@ class CassandraSubOp(StrEnum):
 
 class CassandraStartRequest(NodeRequest):
     tokens: Optional[List[str]]
+    replace_address_first_boot: Optional[str]
+    skip_bootstrap_streaming: Optional[bool]
 
 
 class CassandraGetSchemaHashResult(NodeResult):

--- a/astacus/coordinator/plugins/cassandra/plugin.py
+++ b/astacus/coordinator/plugins/cassandra/plugin.py
@@ -12,7 +12,14 @@ from astacus.common.cassandra.config import CassandraClientConfiguration, SNAPSH
 from astacus.common.snapshot import SnapshotGroup
 from astacus.coordinator.cluster import Cluster
 from astacus.coordinator.plugins import base
-from astacus.coordinator.plugins.base import CoordinatorPlugin, OperationContext, Step, StepFailedError, StepsContext
+from astacus.coordinator.plugins.base import (
+    CoordinatorPlugin,
+    MapNodesStep,
+    OperationContext,
+    Step,
+    StepFailedError,
+    StepsContext,
+)
 from astacus.coordinator.plugins.cassandra import backup_steps, restore_steps
 from dataclasses import dataclass
 from typing import List, Optional
@@ -95,6 +102,7 @@ class CassandraPlugin(CoordinatorPlugin):
             base.BackupNameStep(json_storage=context.json_storage, requested_name=req.name),
             base.BackupManifestStep(json_storage=context.json_storage),
             restore_steps.ParsePluginManifestStep(),
+            base.MapNodesStep(partial_restore_nodes=req.partial_restore_nodes),
         ] + cluster_restore_steps
 
     def get_restore_schema_from_snapshot_steps(self, *, context: OperationContext, req: ipc.RestoreRequest) -> List[Step]:

--- a/astacus/coordinator/plugins/cassandra/plugin.py
+++ b/astacus/coordinator/plugins/cassandra/plugin.py
@@ -42,6 +42,21 @@ class CassandraSubOpStep(Step[None]):
 
 
 @dataclass
+class CassandraRestoreSubOpStep(Step[None]):
+    op: ipc.CassandraSubOp
+
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
+        node_to_backup_index = context.get_result(MapNodesStep)
+        nodes = [
+            cluster.nodes[node_index]
+            for node_index, backup_index in enumerate(node_to_backup_index)
+            if backup_index is not None
+        ]
+
+        await run_subop(cluster, self.op, nodes=nodes, result_class=ipc.NodeResult)
+
+
+@dataclass
 class ValidateConfigurationStep(Step[None]):
     nodes: List[CassandraConfigurationNode]
 
@@ -87,10 +102,7 @@ class CassandraPlugin(CoordinatorPlugin):
         ]
 
     def get_restore_steps(self, *, context: OperationContext, req: ipc.RestoreRequest) -> List[Step]:
-        # The nodes are not really used for now; perhaps they should be, at some point?
-        # their validity is checked just for symmetry with backup, for now.
         nodes = self.nodes or [CassandraConfigurationNode(listen_address=self.client.get_listen_address())]
-
         cluster_restore_steps = (
             self.get_restore_schema_from_snapshot_steps(context=context, req=req)
             if req.partial_restore_nodes
@@ -106,19 +118,23 @@ class CassandraPlugin(CoordinatorPlugin):
         ] + cluster_restore_steps
 
     def get_restore_schema_from_snapshot_steps(self, *, context: OperationContext, req: ipc.RestoreRequest) -> List[Step]:
+        assert self.nodes is not None
+
         return [
             base.RestoreStep(storage_name=context.storage_name, partial_restore_nodes=req.partial_restore_nodes),
-            CassandraSubOpStep(op=ipc.CassandraSubOp.restore_snapshot_with_schema),
-            restore_steps.StartCassandraStep(partial_restore_nodes=req.partial_restore_nodes, override_tokens=True),
+            CassandraRestoreSubOpStep(op=ipc.CassandraSubOp.restore_snapshot_with_schema),
+            restore_steps.StopReplacedNodesStep(partial_restore_nodes=req.partial_restore_nodes, cassandra_nodes=self.nodes),
+            restore_steps.StartCassandraStep(replace_backup_nodes=True, override_tokens=True, cassandra_nodes=self.nodes),
             restore_steps.WaitCassandraUpStep(duration=self.restore_start_timeout),
         ]
 
     def get_restore_schema_from_manifest_steps(self, *, context: OperationContext, req: ipc.RestoreRequest) -> List[Step]:
+        assert self.nodes is not None
         client = CassandraClient(self.client)
 
         return [
             # Start cassandra with backed up token distribution + set schema + stop it
-            restore_steps.StartCassandraStep(partial_restore_nodes=req.partial_restore_nodes, override_tokens=True),
+            restore_steps.StartCassandraStep(override_tokens=True, cassandra_nodes=self.nodes),
             restore_steps.WaitCassandraUpStep(duration=self.restore_start_timeout),
             restore_steps.RestorePreDataStep(client=client),
             CassandraSubOpStep(op=ipc.CassandraSubOp.stop_cassandra),
@@ -127,7 +143,7 @@ class CassandraPlugin(CoordinatorPlugin):
             CassandraSubOpStep(op=ipc.CassandraSubOp.restore_snapshot),
             # restart cassandra and do the final actions with data available
             # not configuring tokens here, because we've already bootstrapped the ring when restoring schema
-            restore_steps.StartCassandraStep(partial_restore_nodes=req.partial_restore_nodes, override_tokens=False),
+            restore_steps.StartCassandraStep(override_tokens=False, cassandra_nodes=self.nodes),
             restore_steps.WaitCassandraUpStep(duration=self.restore_start_timeout),
             restore_steps.RestorePostDataStep(client=client),
         ]

--- a/astacus/coordinator/plugins/cassandra/restore_steps.py
+++ b/astacus/coordinator/plugins/cassandra/restore_steps.py
@@ -5,7 +5,7 @@ cassandra backup/restore plugin steps
 
 """
 
-from .model import CassandraManifest
+from .model import CassandraConfigurationNode, CassandraManifest, CassandraManifestNode
 from .utils import get_schema_hash, run_subop
 from astacus.common import ipc, utils
 from astacus.common.cassandra.client import CassandraClient
@@ -48,9 +48,40 @@ class ParsePluginManifestStep(Step[CassandraManifest]):
 
 
 @dataclass
-class StartCassandraStep(Step[None]):
+class StopReplacedNodesStep(Step[None]):
     partial_restore_nodes: Optional[List[ipc.PartialRestoreRequestNode]]
+    cassandra_nodes: List[CassandraConfigurationNode]
+
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
+        node_to_backup_index = context.get_result(MapNodesStep)
+        cassandra_manifest = context.get_result(ParsePluginManifestStep)
+
+        nodes_to_stop = []
+        for backup_index in node_to_backup_index:
+            if backup_index is None:
+                continue
+            backup_node = cassandra_manifest.nodes[backup_index]
+            node_index = self.find_matching_cassandra_index(backup_node)
+            if node_index is None:
+                logger.warning("Failed to match backup node %s, assuming no longer in cluster -> not stopping it")
+                continue
+            nodes_to_stop.append(cluster.nodes[node_index])
+
+        if nodes_to_stop:
+            await run_subop(cluster, ipc.CassandraSubOp.stop_cassandra, nodes=nodes_to_stop, result_class=ipc.NodeResult)
+
+    def find_matching_cassandra_index(self, backup_node: CassandraManifestNode) -> Optional[int]:
+        for cassandra_index, cassandra_node in enumerate(self.cassandra_nodes):
+            if backup_node.matches_configuration_node(cassandra_node):
+                return cassandra_index
+        return None
+
+
+@dataclass
+class StartCassandraStep(Step[None]):
     override_tokens: bool
+    cassandra_nodes: List[CassandraConfigurationNode]
+    replace_backup_nodes: bool = False
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
         node_to_backup_index = context.get_result(MapNodesStep)
@@ -61,11 +92,25 @@ class StartCassandraStep(Step[None]):
         for node_index, backup_index in enumerate(node_to_backup_index):
             if backup_index is None:
                 continue
-            nodes.append(cluster.nodes[node_index])
+            coordinator = cluster.nodes[node_index]
+            backup_node = plugin_manifest.nodes[backup_index]
+            nodes.append(coordinator)
             tokens: Optional[List[str]] = None
+            replace_address_first_boot: Optional[str] = None
+            skip_bootstrap_streaming: Optional[bool] = None
             if self.override_tokens:
-                tokens = plugin_manifest.nodes[backup_index].tokens
-            reqs.append(ipc.CassandraStartRequest(tokens=tokens))
+                tokens = backup_node.tokens
+            backup_node_in_cluster = any(n for n in self.cassandra_nodes if backup_node.matches_configuration_node(n))
+            if self.replace_backup_nodes and backup_node_in_cluster:
+                replace_address_first_boot = backup_node.listen_address
+                skip_bootstrap_streaming = True
+            reqs.append(
+                ipc.CassandraStartRequest(
+                    tokens=tokens,
+                    replace_address_first_boot=replace_address_first_boot,
+                    skip_bootstrap_streaming=skip_bootstrap_streaming,
+                )
+            )
 
         await run_subop(cluster, ipc.CassandraSubOp.start_cassandra, nodes=nodes, reqs=reqs, result_class=ipc.NodeResult)
 

--- a/astacus/coordinator/plugins/cassandra/restore_steps.py
+++ b/astacus/coordinator/plugins/cassandra/restore_steps.py
@@ -12,13 +12,7 @@ from astacus.common.cassandra.client import CassandraClient
 from astacus.common.cassandra.schema import CassandraKeyspace
 from astacus.coordinator.cluster import Cluster
 from astacus.coordinator.config import CoordinatorNode
-from astacus.coordinator.plugins.base import (
-    BackupManifestStep,
-    get_node_to_backup_index,
-    Step,
-    StepFailedError,
-    StepsContext,
-)
+from astacus.coordinator.plugins.base import BackupManifestStep, MapNodesStep, Step, StepFailedError, StepsContext
 from cassandra import metadata as cm
 from dataclasses import dataclass
 from typing import Iterable, List, Optional
@@ -59,13 +53,7 @@ class StartCassandraStep(Step[None]):
     override_tokens: bool
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
-        backup_manifest = context.get_result(BackupManifestStep)
-
-        node_to_backup_index = get_node_to_backup_index(
-            partial_restore_nodes=self.partial_restore_nodes,
-            snapshot_results=backup_manifest.snapshot_results,
-            nodes=cluster.nodes,
-        )
+        node_to_backup_index = context.get_result(MapNodesStep)
 
         reqs: List[ipc.NodeRequest] = []
         nodes: List[CoordinatorNode] = []

--- a/astacus/coordinator/plugins/clickhouse/plugin.py
+++ b/astacus/coordinator/plugins/clickhouse/plugin.py
@@ -43,6 +43,7 @@ from astacus.coordinator.plugins.base import (
     DownloadKeptBackupManifestsStep,
     ListBackupsStep,
     ListHexdigestsStep,
+    MapNodesStep,
     OperationContext,
     RestoreStep,
     SnapshotStep,
@@ -158,6 +159,7 @@ class ClickHousePlugin(CoordinatorPlugin):
                 replicated_databases_zookeeper_path=self.replicated_databases_zookeeper_path,
                 sync_timeout=self.sync_databases_timeout,
             ),
+            MapNodesStep(partial_restore_nodes=req.partial_restore_nodes),
             RestoreStep(storage_name=context.storage_name, partial_restore_nodes=req.partial_restore_nodes),
             AttachMergeTreePartsStep(
                 clients=clients,

--- a/astacus/coordinator/plugins/files.py
+++ b/astacus/coordinator/plugins/files.py
@@ -19,6 +19,7 @@ from .base import (
     BackupNameStep,
     CoordinatorPlugin,
     ListHexdigestsStep,
+    MapNodesStep,
     OperationContext,
     RestoreStep,
     SnapshotStep,
@@ -48,5 +49,6 @@ class FilesPlugin(CoordinatorPlugin):
         return [
             BackupNameStep(json_storage=context.json_storage, requested_name=req.name),
             BackupManifestStep(json_storage=context.json_storage),
+            MapNodesStep(partial_restore_nodes=req.partial_restore_nodes),
             RestoreStep(storage_name=context.storage_name, partial_restore_nodes=req.partial_restore_nodes),
         ]

--- a/astacus/node/cassandra.py
+++ b/astacus/node/cassandra.py
@@ -167,10 +167,14 @@ class CassandraStartOp(NodeOp[ipc.CassandraStartRequest, ipc.NodeResult]):
             config = yaml.safe_load(config_read_fh)
         progress.add_success()
 
-        config["auto_bootstrap"] = False
+        config["auto_bootstrap"] = self.req.replace_address_first_boot is not None
         if self.req.tokens:
             config["initial_token"] = ", ".join(self.req.tokens)
             config["num_tokens"] = len(self.req.tokens)
+        if self.req.replace_address_first_boot:
+            config["replace_address_first_boot"] = self.req.replace_address_first_boot
+        if self.req.skip_bootstrap_streaming:
+            config["skip_bootstrap_streaming"] = True
         with tempfile.NamedTemporaryFile(mode="w") as config_fh:
             yaml.safe_dump(config, config_fh)
             config_fh.flush()

--- a/tests/unit/coordinator/plugins/cassandra/test_plugin.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_plugin.py
@@ -6,6 +6,7 @@ See LICENSE for details
 from astacus.common import ipc
 from astacus.coordinator.plugins.base import StepFailedError
 from astacus.coordinator.plugins.cassandra import plugin
+from astacus.coordinator.plugins.cassandra.model import CassandraConfigurationNode
 from tests.unit.node.test_node_cassandra import CassandraTestConfig
 from types import SimpleNamespace
 
@@ -15,7 +16,9 @@ import pytest
 @pytest.fixture(name="cplugin")
 def fixture_cplugin(mocker, tmpdir):
     ctc = CassandraTestConfig(mocker=mocker, tmpdir=tmpdir)
-    yield plugin.CassandraPlugin(client=ctc.cassandra_client_config)
+    yield plugin.CassandraPlugin(
+        client=ctc.cassandra_client_config, nodes=[CassandraConfigurationNode(listen_address="127.0.0.1")]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/coordinator/plugins/cassandra/test_restore_steps.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_restore_steps.py
@@ -5,11 +5,13 @@ See LICENSE for details
 
 from astacus.common import ipc
 from astacus.common.cassandra.schema import CassandraSchema
+from astacus.coordinator.config import CoordinatorNode
 from astacus.coordinator.plugins import base
 from astacus.coordinator.plugins.cassandra import restore_steps
-from astacus.coordinator.plugins.cassandra.model import CassandraManifest, CassandraManifestNode
+from astacus.coordinator.plugins.cassandra.model import CassandraConfigurationNode, CassandraManifest, CassandraManifestNode
 from tests.unit.coordinator.plugins.cassandra.builders import build_keyspace
 from types import SimpleNamespace
+from uuid import UUID
 
 import datetime
 import pytest
@@ -17,20 +19,42 @@ import pytest
 # TBD: Eventually multinode configuration would be perhaps interesting to test too
 
 
+def _manifest_node(node_index: int) -> CassandraManifestNode:
+    return CassandraManifestNode(
+        address=f"127.0.0.{node_index}",
+        host_id=UUID(int=node_index),
+        listen_address=f"::{node_index}",
+        rack=f"r{node_index}",
+        tokens=[f"token{node_index}"],
+    )
+
+
+def _configuration_node(node_index: int) -> CassandraConfigurationNode:
+    return CassandraConfigurationNode(
+        address=f"127.0.0.{node_index}",
+        host_id=UUID(int=node_index),
+        listen_address=f"::{node_index}",
+        tokens=[f"token{node_index}"],
+    )
+
+
+def _coordinator_node(node_index: int) -> CoordinatorNode:
+    return CoordinatorNode(
+        url=f"http:://localhost:{node_index}",
+        az=f"az-{node_index}",
+    )
+
+
+_pr_node = ipc.PartialRestoreRequestNode
+
+
 @pytest.mark.parametrize("override_tokens", [False, True])
+@pytest.mark.parametrize("replace_backup_nodes", [False, True])
 @pytest.mark.asyncio
-async def test_step_start_cassandra(mocker, override_tokens):
+async def test_step_start_cassandra(mocker, override_tokens, replace_backup_nodes):
     plugin_manifest = CassandraManifest(
         cassandra_schema=CassandraSchema(keyspaces=[]),
-        nodes=[
-            CassandraManifestNode(
-                address="127.0.0.1",
-                host_id="12345678123456781234567812345678",
-                listen_address="::1",
-                rack="unused",
-                tokens=["token0"],
-            )
-        ],
+        nodes=[_manifest_node(1)],
     )
 
     backup_manifest = ipc.BackupManifest(
@@ -42,24 +66,79 @@ async def test_step_start_cassandra(mocker, override_tokens):
         plugin_data=plugin_manifest.dict(),
     )
 
+    nodes = [_coordinator_node(1)]
     node_to_backup_index = [0]
 
     def get_result(cl):
-        if cl == base.BackupManifestStep:
-            return backup_manifest
-        if cl == restore_steps.ParsePluginManifestStep:
-            return plugin_manifest
-        if cl == base.MapNodesStep:
-            return node_to_backup_index
-        raise NotImplementedError(cl)
+        match cl:
+            case base.BackupManifestStep:
+                return backup_manifest
+            case restore_steps.ParsePluginManifestStep:
+                return plugin_manifest
+            case base.MapNodesStep:
+                return node_to_backup_index
+            case _:
+                raise NotImplementedError(cl)
 
-    mocker.patch.object(restore_steps, "run_subop")
+    expected_reqs = [
+        ipc.CassandraStartRequest(
+            tokens=["token1"] if override_tokens else None,
+            replace_address_first_boot="::1" if replace_backup_nodes else None,
+            skip_bootstrap_streaming=True if replace_backup_nodes else None,
+        )
+    ]
 
-    step = restore_steps.StartCassandraStep(partial_restore_nodes=None, override_tokens=override_tokens)
+    run_subop = mocker.patch.object(restore_steps, "run_subop")
+
+    step = restore_steps.StartCassandraStep(
+        replace_backup_nodes=replace_backup_nodes, override_tokens=override_tokens, cassandra_nodes=[_configuration_node(1)]
+    )
     context = SimpleNamespace(get_result=get_result)
-    cluster = SimpleNamespace(nodes=[SimpleNamespace(az="az1")])
+    cluster = SimpleNamespace(nodes=nodes)
     result = await step.run_step(cluster, context)
     assert result is None
+    run_subop.assert_awaited_once_with(
+        cluster,
+        ipc.CassandraSubOp.start_cassandra,
+        nodes=nodes,
+        reqs=expected_reqs,
+        result_class=ipc.NodeResult,
+    )
+
+
+@pytest.mark.asyncio
+async def test_step_stop_replaced_nodes(mocker):
+    # Node 3 is replacing node 1.
+    manifest_nodes = [_manifest_node(1), _manifest_node(2)]
+    cassandra_nodes = [_configuration_node(1), _configuration_node(2), _configuration_node(3)]
+    nodes = [_coordinator_node(1), _coordinator_node(2), _coordinator_node(3)]
+    node_to_backup_index = [None, None, 0]
+    partial_restore_nodes = [_pr_node(backup_index=0, node_index=2)]
+
+    plugin_manifest = CassandraManifest(cassandra_schema=CassandraSchema(keyspaces=[]), nodes=manifest_nodes)
+
+    def get_result(cl):
+        match cl:
+            case restore_steps.ParsePluginManifestStep:
+                return plugin_manifest
+            case base.MapNodesStep:
+                return node_to_backup_index
+            case _:
+                raise NotImplementedError(cl)
+
+    run_subop = mocker.patch.object(restore_steps, "run_subop")
+
+    step = restore_steps.StopReplacedNodesStep(partial_restore_nodes=partial_restore_nodes, cassandra_nodes=cassandra_nodes)
+    context = SimpleNamespace(get_result=get_result)
+    cluster = SimpleNamespace(nodes=nodes)
+    result = await step.run_step(cluster, context)
+    assert result is None
+    run_subop.assert_awaited_once_with(
+        cluster,
+        ipc.CassandraSubOp.stop_cassandra,
+        nodes=[_coordinator_node(1)],
+        result_class=ipc.NodeResult,
+    )
 
 
 class AsyncIterableWrapper:

--- a/tests/unit/coordinator/plugins/cassandra/test_restore_steps.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_restore_steps.py
@@ -42,11 +42,15 @@ async def test_step_start_cassandra(mocker, override_tokens):
         plugin_data=plugin_manifest.dict(),
     )
 
+    node_to_backup_index = [0]
+
     def get_result(cl):
         if cl == base.BackupManifestStep:
             return backup_manifest
         if cl == restore_steps.ParsePluginManifestStep:
             return plugin_manifest
+        if cl == base.MapNodesStep:
+            return node_to_backup_index
         raise NotImplementedError(cl)
 
     mocker.patch.object(restore_steps, "run_subop")

--- a/tests/unit/coordinator/plugins/test_m3db.py
+++ b/tests/unit/coordinator/plugins/test_m3db.py
@@ -13,7 +13,7 @@ from astacus.common.storage import MultiStorage
 from astacus.coordinator.config import CoordinatorConfig
 from astacus.coordinator.coordinator import Coordinator, SteppedCoordinatorOp
 from astacus.coordinator.plugins import m3db
-from astacus.coordinator.plugins.base import BackupManifestStep, StepsContext
+from astacus.coordinator.plugins.base import BackupManifestStep, MapNodesStep, StepsContext
 from astacus.coordinator.plugins.m3db import (
     get_etcd_prefixes,
     InitStep,
@@ -134,7 +134,7 @@ class RestoreTest:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("rt", [RestoreTest(fail_at=i) for i in range(3)] + [RestoreTest(), RestoreTest(partial=True)])
+@pytest.mark.parametrize("rt", [RestoreTest(fail_at=i) for i in range(3)] + [RestoreTest()])
 async def test_m3_restore(coordinator: Coordinator, plugin: M3DBPlugin, etcd_client: ETCDClient, rt: RestoreTest):
     partial_restore_nodes: Optional[List[ipc.PartialRestoreRequestNode]] = None
     if rt.partial:
@@ -143,6 +143,7 @@ async def test_m3_restore(coordinator: Coordinator, plugin: M3DBPlugin, etcd_cli
         c=coordinator,
         attempts=1,
         steps=[
+            MapNodesStep(partial_restore_nodes=partial_restore_nodes),
             RewriteEtcdStep(placement_nodes=plugin.placement_nodes, partial_restore_nodes=partial_restore_nodes),
             RestoreEtcdStep(etcd_client=etcd_client, partial_restore_nodes=partial_restore_nodes),
         ],


### PR DESCRIPTION
Base it upon the node replacement for dead nodes (replace_address), but
skip the streaming stage, since we're downloading the data from object
storage. This is not production-ready yet, because the current process
loses all the writes since the last backup when restoring. Incremental
backup and restore to be introduced later.

After downloading the snapshot, stop Cassandra on the node we took the
snapshot of. That node might no longer be in the cluster, we attempt
to match it to configuration nodes the same way we match configuration
nodes to live cluster nodes when creating the backup.

Then start the replacement node with replace_address and
skip_bootstrap_streaming parameters. Wait until it is up, at this point
Cassandra should remove the old node from gossip because we instructed
it to perform a replacement.